### PR TITLE
ci: upgrade npm before publish — trusted publishing needs npm >= 11.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,11 @@ jobs:
       - run: npm run build
       - run: npm test
 
+      # Trusted publishing (OIDC -> registry token exchange) needs npm >= 11.5;
+      # Node 22 ships npm 10, which signs provenance but then PUTs without
+      # credentials and npm masks the rejection as a 404.
+      - run: npm install -g npm@latest
+
       # --provenance publishes a signed attestation linking the tarball to this
       # repository, commit and workflow run.
       - run: npm publish --provenance


### PR DESCRIPTION
The first v1.3.0 publish run failed with E404 on PUT: Node 22 ships npm 10.9.8, which signs the provenance attestation but does not know the OIDC → registry token exchange, so the PUT went out unauthenticated and npm masked the rejection as a 404.

Fix: install npm@latest in the publish job before `npm publish --provenance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)