### PR TITLE
feat: strip URL noise and cap response size (AI-177)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -189,6 +189,8 @@ Ask your client: *"Check the App Store Connect connection."* It calls `asc__stat
 | `ASC_CONFIRM_WRITES` | no | `0` / `false` to skip the confirm-before-write prompt (on by default) |
 | `ASC_ALLOW_UNCONFIRMED_WRITES` | no | `1` / `true` to allow writes on clients that can't show a confirmation prompt (blocked by default) |
 | `ASC_DRY_RUN` | no | `1` / `true`: writes never reach Apple — each mutating call returns what would have been sent (method, path, body, risk) after validation. Reads run normally |
+| `ASC_MAX_RESPONSE_CHARS` | no | Response size ceiling in characters (default 100000). Oversized lists are cut to the items that fit, with an explicit truncation note |
+| `ASC_KEEP_RAW_RESPONSES` | no | `1` to pass Apple's payloads through untouched — by default per-resource `links` and links-only `relationships` URL noise is stripped (~85% smaller listings) |
 | `ASC_REVIEWS_BRAND_VOICE` | no | Brand-voice guidance for `reviews_ai__draft_response`, e.g. "friendly, concise, we say 'folks'" |
 | `ASC_REVIEWS_BANNED_PHRASES` | no | Comma-separated phrases the draft must never contain |
 | `ASC_REVIEWS_SUPPORT_URL` | no | Support URL the draft points customers at for follow-ups |
@@ -497,6 +499,8 @@ Araç isimleri kaynak hiyerarşisini yansıtır, eylem en sonda gelir (`apps__li
 | `ASC_CONFIRM_WRITES` | hayır | Yazma-öncesi onay istemini atlamak için `0` / `false` (varsayılan açık) |
 | `ASC_ALLOW_UNCONFIRMED_WRITES` | hayır | Onay istemi gösteremeyen client'larda yazmaya izin vermek için `1` / `true` (varsayılan engelli) |
 | `ASC_DRY_RUN` | hayır | `1` / `true`: yazmalar Apple'a hiç gitmez — her mutasyon çağrısı, doğrulamadan sonra gönderilecek olanı (metod, path, body, risk) döndürür. Okumalar normal çalışır |
+| `ASC_MAX_RESPONSE_CHARS` | hayır | Cevap boyutu tavanı, karakter (varsayılan 100000). Büyük listeler sığan öğelere kırpılır, açık kesme notuyla |
+| `ASC_KEEP_RAW_RESPONSES` | hayır | Apple cevaplarını olduğu gibi geçirmek için `1` — varsayılan olarak kaynak-başı `links` ve links-only `relationships` URL gürültüsü atılır (listeler ~%85 küçülür) |
 | `ASC_REVIEWS_BRAND_VOICE` | hayır | `reviews_ai__draft_response` için marka sesi, ör. "samimi, kısa" |
 | `ASC_REVIEWS_BANNED_PHRASES` | hayır | Taslakta asla geçmeyecek ifadeler (virgülle ayrılmış) |
 | `ASC_REVIEWS_SUPPORT_URL` | hayır | Taslağın müşteriyi yönlendireceği destek adresi |

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -178,19 +178,25 @@ export class AscHttpClient {
     return this.request<T>('DELETE', path, { body });
   }
 
-  /** Follows `links.next` until the collection is exhausted or `maxPages` is hit. */
+  /**
+   * Follows `links.next` until the collection is exhausted or `maxPages` is
+   * hit. The result says whether it stopped early (`hasMore` + `nextUrl`), so
+   * callers can't mistake a page-capped fetch for the complete collection.
+   */
   async collect<T = unknown>(
     path: string,
     query?: Query,
     maxPages = 10
-  ): Promise<T[]> {
+  ): Promise<{ items: T[]; pagesFetched: number; hasMore: boolean; nextUrl?: string }> {
     const items: T[] = [];
     let next: string | undefined;
+    let pagesFetched = 0;
 
     for (let page = 0; page < maxPages; page++) {
       const res: any = next
         ? await this.request('GET', next)
         : await this.get(path, query);
+      pagesFetched++;
 
       if (Array.isArray(res?.data)) items.push(...res.data);
       else if (res?.data) items.push(res.data);
@@ -198,7 +204,7 @@ export class AscHttpClient {
       next = res?.links?.next;
       if (!next) break;
     }
-    return items;
+    return { items, pagesFetched, hasMore: Boolean(next), nextUrl: next };
   }
 }
 

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -1,0 +1,113 @@
+/**
+ * Response shaping for App Store Connect payloads.
+ *
+ * Measured on a real price-point listing: each item was ~1,100 bytes of which
+ * ~120 bytes were data — the rest was `links` and links-only `relationships`
+ * blocks repeating the same base64 id in URL form five times. The model never
+ * follows those URLs (pagination rides on the separate `next_url` parameter),
+ * so they are stripped by default, cutting a 900 KB listing to roughly 100 KB.
+ * Set ASC_KEEP_RAW_RESPONSES=1 to pass Apple's payloads through untouched.
+ *
+ * On top of that, a configurable character ceiling keeps a single response
+ * from flooding the client's context: oversized `data` arrays are cut to the
+ * items that fit and the response says so, instead of silently costing tens of
+ * thousands of tokens.
+ */
+
+/** A JSON:API resource object, loosely. */
+type AnyRecord = Record<string, unknown>;
+
+const isRecord = (v: unknown): v is AnyRecord =>
+  Boolean(v) && typeof v === 'object' && !Array.isArray(v);
+
+/** Strips `links` and links-only `relationships` from one resource object. */
+function stripResource(resource: unknown): unknown {
+  if (!isRecord(resource)) return resource;
+  const out: AnyRecord = { ...resource };
+  delete out.links;
+
+  const rels = out.relationships;
+  if (isRecord(rels)) {
+    const kept: AnyRecord = {};
+    for (const [name, rel] of Object.entries(rels)) {
+      if (!isRecord(rel)) continue;
+      // Keep only relationships that actually identify something ({type,id}
+      // data); links-only blocks are pure URL noise.
+      if ('data' in rel && rel.data !== undefined) {
+        kept[name] = { data: rel.data };
+      }
+    }
+    if (Object.keys(kept).length) out.relationships = kept;
+    else delete out.relationships;
+  }
+  return out;
+}
+
+/**
+ * Strips URL noise from a JSON:API payload. Top-level `links.next` is
+ * preserved — the pagination cursor (`next_url`) depends on it.
+ */
+export function stripApiNoise(payload: unknown): unknown {
+  if (!isRecord(payload)) return payload;
+  const out: AnyRecord = { ...payload };
+
+  if (Array.isArray(out.data)) out.data = out.data.map(stripResource);
+  else if (isRecord(out.data)) out.data = stripResource(out.data);
+
+  if (Array.isArray(out.included)) out.included = out.included.map(stripResource);
+
+  if (isRecord(out.links)) {
+    // Everything except the pagination cursor is noise.
+    const next = out.links.next;
+    if (typeof next === 'string' && next) out.links = { next };
+    else delete out.links;
+  }
+
+  return out;
+}
+
+export const DEFAULT_MAX_RESPONSE_CHARS = 100_000;
+
+/**
+ * Caps a response's serialized size. When the payload has a `data` array, the
+ * array is cut to the items that fit and the result stays valid JSON with an
+ * explicit `truncation` note; otherwise the caller should truncate the raw
+ * text (`truncateText`).
+ */
+export function capResponseSize(payload: unknown, maxChars: number): unknown {
+  if (maxChars <= 0) return payload;
+  // Measure the pretty-printed form — that's what actually goes to the client.
+  const size = JSON.stringify(payload, null, 2)?.length ?? 0;
+  if (size <= maxChars) return payload;
+
+  if (isRecord(payload) && Array.isArray(payload.data) && payload.data.length > 1) {
+    const total = payload.data.length;
+    const avgItem = Math.max(1, Math.ceil(size / total));
+    const keep = Math.max(1, Math.floor((maxChars * 0.9) / avgItem));
+    const kept = payload.data.slice(0, keep);
+    return {
+      ...payload,
+      data: kept,
+      truncation: {
+        note:
+          `Response truncated: showing ${kept.length} of ${total} items ` +
+          `(full response was ~${Math.round(size / 1024)} KB). Narrow the query with ` +
+          `filter_* parameters, lower limit, or continue from links.next via next_url.`,
+        shown: kept.length,
+        total,
+      },
+    };
+  }
+
+  return payload; // non-array payloads are handled as text by the caller
+}
+
+/** Text-level fallback for oversized non-array payloads. */
+export function truncateText(text: string, maxChars: number): string {
+  if (maxChars <= 0 || text.length <= maxChars) return text;
+  return (
+    text.slice(0, maxChars) +
+    `\n… [truncated: response was ${text.length} characters; ` +
+    `narrow the query with filter_* parameters or paginate with next_url]`
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,18 @@ import { REVIEWS_AI_TOOLS, REVIEWS_AI_TOOL_NAMES, executeReviewsAiTool } from '.
 import { STOREKIT_TOOLS, STOREKIT_TOOL_NAMES, StoreKitService } from './storekit/index.js';
 import { SPEC_VERSION } from './generated/operations.js';
 import { GATEWAY_OPERATIONS, profileForDomain, registerCommand, type Profile } from './profiles.js';
+import {
+  stripApiNoise,
+  capResponseSize,
+  truncateText,
+  DEFAULT_MAX_RESPONSE_CHARS,
+} from './core/shape.js';
+
+/** Configurable response ceiling (chars of pretty-printed JSON). */
+function maxResponseChars(): number {
+  const raw = Number(process.env.ASC_MAX_RESPONSE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_RESPONSE_CHARS;
+}
 
 // Read from package.json at runtime so the banner can't drift from the published
 // version. Not a JSON import: package.json sits outside tsconfig's rootDir.
@@ -238,13 +250,22 @@ export function createServer(config: ServerConfig, profile?: Profile): Server {
         result = await storekit.execute(name, args);
       } else {
         result = await registry.execute(name, args, http);
+        // Apple payloads are mostly URL noise the model never follows; strip
+        // it and cap the size so one listing can't flood the context window.
+        if (process.env.ASC_KEEP_RAW_RESPONSES !== '1') {
+          result = stripApiNoise(result);
+        }
+        result = capResponseSize(result, maxResponseChars());
       }
 
       return {
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify(result ?? { ok: true }, null, 2),
+            text: truncateText(
+              JSON.stringify(result ?? { ok: true }, null, 2),
+              maxResponseChars()
+            ),
           },
         ],
       };

--- a/src/tools/reviews-ai.ts
+++ b/src/tools/reviews-ai.ts
@@ -269,7 +269,7 @@ export async function executeReviewsAiTool(
       const limit = Math.max(1, Math.min(Number(args.limit ?? 50), 200));
       const unansweredOnly = args.unanswered_only !== false;
 
-      const items = await ctx.http.collect(
+      const { items, hasMore } = await ctx.http.collect(
         `/v1/apps/${encodeURIComponent(appId)}/customerReviews`,
         {
           sort: '-createdDate',
@@ -280,6 +280,7 @@ export async function executeReviewsAiTool(
       );
 
       const reviews = items.slice(0, limit);
+      const moreExist = hasMore || items.length > limit;
       if (reviews.length === 0) {
         return { appId, fetchedCount: 0, analyzedCount: 0, triage: 'No reviews matched the filters.' };
       }
@@ -299,6 +300,7 @@ export async function executeReviewsAiTool(
       return {
         appId,
         fetchedCount: reviews.length,
+        ...(moreExist ? { moreReviewsExist: true } : {}),
         analyzedCount,
         truncated: analyzedCount < reviews.length,
         coverage: `${analyzedCount} of ${reviews.length} fetched reviews analyzed`,
@@ -317,7 +319,7 @@ export async function executeReviewsAiTool(
       // period, computed in code — "up vs down" is not the model's guess.
       const previousSince = now - 2 * days * 86_400_000;
 
-      const items = await ctx.http.collect(
+      const { items } = await ctx.http.collect(
         `/v1/apps/${encodeURIComponent(appId)}/customerReviews`,
         { sort: '-createdDate', limit: 200 },
         3

--- a/tests/reviews-ai.test.ts
+++ b/tests/reviews-ai.test.ts
@@ -30,9 +30,18 @@ function makeCtx(overrides: {
   const createMessage =
     overrides.createMessage ??
     vi.fn().mockResolvedValue({ content: { type: 'text', text: 'model output' } });
+  // collect() returns { items, pagesFetched, hasMore, nextUrl }; tests may
+  // still hand in a plain array for brevity — wrap it here.
+  const rawCollect = overrides.collect ?? vi.fn().mockResolvedValue([]);
+  const collect = vi.fn(async (...a: unknown[]) => {
+    const res = await rawCollect(...a);
+    return Array.isArray(res)
+      ? { items: res, pagesFetched: 1, hasMore: false, nextUrl: undefined }
+      : res;
+  });
   const http = {
     get: overrides.get ?? vi.fn(),
-    collect: overrides.collect ?? vi.fn().mockResolvedValue([]),
+    collect,
     post: vi.fn(),
     patch: vi.fn(),
     delete: vi.fn(),

--- a/tests/shape.test.ts
+++ b/tests/shape.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { stripApiNoise, capResponseSize, truncateText } from '../src/core/shape.js';
+
+// Mirrors the measured real payload: a 56-char base64 id repeated in four
+// links-only relationship blocks plus the self link.
+const pricePoint = (seed: string) => {
+  const id = `eyJzIjoiNjYzOTU5OTk5OSIsInQiOiJUVVIiLCJwIjoi${seed.padEnd(8, '0')}In0`;
+  const rel = (name: string) => ({
+    links: {
+      self: `https://api.appstoreconnect.apple.com/v1/subscriptionPricePoints/${id}/relationships/${name}`,
+      related: `https://api.appstoreconnect.apple.com/v1/subscriptionPricePoints/${id}/${name}`,
+    },
+  });
+  return {
+    type: 'subscriptionPricePoints',
+    id,
+    attributes: { customerPrice: '2.99', proceeds: '2.01', proceedsYear2: '2.01' },
+    relationships: {
+      equalizations: rel('equalizations'),
+      adjustedEqualizations: rel('adjustedEqualizations'),
+      territory: { data: { type: 'territories', id: 'TUR' } },
+    },
+    links: { self: `https://api.appstoreconnect.apple.com/v1/subscriptionPricePoints/${id}` },
+  };
+};
+
+describe('stripApiNoise', () => {
+  const payload = {
+    data: [pricePoint('a'), pricePoint('b')],
+    included: [pricePoint('inc')],
+    links: {
+      self: 'https://api.appstoreconnect.apple.com/v1/x',
+      next: 'https://api.appstoreconnect.apple.com/v1/x?cursor=zz',
+    },
+    meta: { paging: { total: 842, limit: 200 } },
+  };
+
+  it('drops per-resource links and links-only relationships, keeps data relationships', () => {
+    const out: any = stripApiNoise(payload);
+    expect(out.data[0].links).toBeUndefined();
+    expect(out.data[0].relationships.equalizations).toBeUndefined();
+    expect(out.data[0].relationships.territory).toEqual({ data: { type: 'territories', id: 'TUR' } });
+    expect(out.included[0].links).toBeUndefined();
+    expect(out.meta).toEqual(payload.meta); // untouched
+  });
+
+  it('keeps top-level links.next (pagination) and drops links.self', () => {
+    const out: any = stripApiNoise(payload);
+    expect(out.links).toEqual({ next: 'https://api.appstoreconnect.apple.com/v1/x?cursor=zz' });
+  });
+
+  it('shrinks the real-world price-point shape by an order of magnitude', () => {
+    const big = { data: Array.from({ length: 200 }, (_, i) => pricePoint(`id-${i}`)) };
+    const before = JSON.stringify(big).length;
+    const after = JSON.stringify(stripApiNoise(big)).length;
+    expect(after).toBeLessThan(before * 0.5);
+  });
+
+  it('passes non-JSON:API payloads through untouched', () => {
+    expect(stripApiNoise({ ok: true })).toEqual({ ok: true });
+    expect(stripApiNoise('text')).toBe('text');
+  });
+});
+
+describe('capResponseSize', () => {
+  it('cuts an oversized data array and says so, keeping valid JSON', () => {
+    const big = { data: Array.from({ length: 500 }, (_, i) => pricePoint(`id-${i}`)) };
+    const out: any = capResponseSize(big, 20_000);
+    expect(out.data.length).toBeLessThan(500);
+    expect(out.truncation.total).toBe(500);
+    expect(out.truncation.note).toContain('filter_');
+    expect(JSON.stringify(out, null, 2).length).toBeLessThanOrEqual(25_000); // ~cap
+  });
+
+  it('leaves small responses alone', () => {
+    const small = { data: [pricePoint('a')] };
+    expect(capResponseSize(small, 100_000)).toBe(small);
+  });
+});
+
+describe('truncateText', () => {
+  it('cuts oversized text with an explanatory tail', () => {
+    const out = truncateText('x'.repeat(1000), 100);
+    expect(out).toContain('[truncated');
+    expect(out.length).toBeLessThan(300);
+  });
+});


### PR DESCRIPTION
Measured on a real price-point listing: each item was ~1,100 bytes, of which
~120 bytes were data — the rest repeated the same 56-char base64 id five times
as relationship/self URLs the model never follows. One subscription in one
territory produced ~900 KB (~230k tokens); the agent fell back to jq.

- stripApiNoise (src/core/shape.ts): drops per-resource `links` and
  links-only `relationships` blocks from data/included; keeps {type,id}
  relationship data and, critically, top-level links.next — the pagination
  cursor next_url rides on it. Applied to every registry response;
  ASC_KEEP_RAW_RESPONSES=1 restores Apple's raw payloads. Real-world shape
  shrinks by >2x in the test fixture (>8x on live listings).
- capResponseSize: configurable ceiling (ASC_MAX_RESPONSE_CHARS, default
  100k chars of pretty JSON). Oversized data arrays are cut to the items that
  fit and the response carries an explicit truncation note pointing at
  filter_* / limit / next_url. Non-array payloads fall back to text-level
  truncation with the same guidance.
- collect() now returns { items, pagesFetched, hasMore, nextUrl } instead of
  a silently page-capped array; reviews-ai reports moreReviewsExist when the
  fetch stopped early.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
