### PR TITLE
feat: confirmation prompt translates opaque ids and heavy fields (AI-202)

### DIFF
--- a/src/core/confirm.ts
+++ b/src/core/confirm.ts
@@ -50,17 +50,125 @@ export interface PreviewableOp {
 
 const MAX_CHANGE_LINES = 10;
 
+/** The slice of AscHttpClient the resolver needs — mockable in tests. */
+export interface RefReader {
+  get<T = unknown>(path: string, query?: Record<string, unknown>): Promise<T>;
+}
+
+/**
+ * Meaning-heavy fields, spelled out in the prompt. A raw
+ * `preserveCurrentPrice = false` reads like a technical flag; its real meaning
+ * is a customer-facing revenue decision, so it must never look routine.
+ */
+export const FIELD_NOTES: Record<string, (value: unknown) => string | undefined> = {
+  preserveCurrentPrice: (v) =>
+    v === false
+      ? '⚠ Existing subscribers WILL be moved to the new price.'
+      : v === true
+        ? 'Existing subscribers keep their current price.'
+        : undefined,
+};
+
+/** Max reference lookups per preview — keeps confirmation latency bounded. */
+const MAX_REF_LOOKUPS = 4;
+
+type RefResolver = (http: RefReader, id: string) => Promise<string | undefined>;
+
+/** Human labels for the reference types that matter most in previews. */
+const REF_RESOLVERS: Record<string, RefResolver> = {
+  subscriptionPricePoints: async (http, id) => {
+    const res: any = await http.get(`/v1/subscriptionPricePoints/${encodeURIComponent(id)}`, {
+      include: 'territory',
+    });
+    const price = res?.data?.attributes?.customerPrice;
+    if (!price) return undefined;
+    const territory: any = (res?.included ?? []).find((i: any) => i?.type === 'territories');
+    const territoryId = territory?.id ?? res?.data?.relationships?.territory?.data?.id;
+    const currency = territory?.attributes?.currency;
+    return `${price}${currency ? ` ${currency}` : ''}${territoryId ? ` (${territoryId})` : ''}`;
+  },
+  subscriptions: async (http, id) => {
+    const res: any = await http.get(`/v1/subscriptions/${encodeURIComponent(id)}`);
+    const a = res?.data?.attributes;
+    return a?.name ? `${a.name}${a.productId ? ` (${a.productId})` : ''}` : undefined;
+  },
+  apps: async (http, id) => {
+    const res: any = await http.get(`/v1/apps/${encodeURIComponent(id)}`);
+    const a = res?.data?.attributes;
+    return a?.name ? `${a.name}${a.bundleId ? ` (${a.bundleId})` : ''}` : undefined;
+  },
+  betaGroups: async (http, id) => {
+    const res: any = await http.get(`/v1/betaGroups/${encodeURIComponent(id)}`);
+    return res?.data?.attributes?.name ?? undefined;
+  },
+};
+
+/** Collects every {type,id} reference in a JSON:API body. */
+function collectRefs(node: unknown, refs: Array<{ type: string; id: string }>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    node.forEach((n) => collectRefs(n, refs));
+    return;
+  }
+  const rec = node as Record<string, unknown>;
+  if (typeof rec.type === 'string' && typeof rec.id === 'string' && REF_RESOLVERS[rec.type]) {
+    refs.push({ type: rec.type, id: rec.id });
+  }
+  for (const v of Object.values(rec)) collectRefs(v, refs);
+}
+
+/**
+ * Resolves the opaque ids in a write body to human labels ("99.99 TRY (TUR)",
+ * "ask quran base 1week (askquran.base.1week)") with at most MAX_REF_LOOKUPS
+ * GET calls. Display is best-effort: a failed lookup leaves the raw id — the
+ * write itself is never affected.
+ */
+export async function resolveBodyRefs(
+  http: RefReader,
+  body: unknown
+): Promise<Map<string, string>> {
+  const refs: Array<{ type: string; id: string }> = [];
+  collectRefs(body, refs);
+
+  const seen = new Set<string>();
+  const unique = refs.filter((r) => {
+    const key = `${r.type}/${r.id}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const labels = new Map<string, string>();
+  await Promise.all(
+    unique.slice(0, MAX_REF_LOOKUPS).map(async ({ type, id }) => {
+      try {
+        const label = await REF_RESOLVERS[type](http, id);
+        if (label) labels.set(`${type}/${id}`, label);
+      } catch {
+        // Best-effort display only — the raw id stays in the preview.
+      }
+    })
+  );
+  return labels;
+}
+
 /**
  * Flattens a JSON:API body into human-readable "field = value" lines:
  * attributes become dotted paths, relationships become "→ type/id" arrows.
  */
-function summarizeBody(body: unknown, lines: string[], prefix = ''): void {
+function summarizeBody(
+  body: unknown,
+  lines: string[],
+  prefix = '',
+  labels?: Map<string, string>
+): void {
   if (lines.length > MAX_CHANGE_LINES || !body || typeof body !== 'object') return;
   for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
     if (lines.length > MAX_CHANGE_LINES) return;
     const path = prefix ? `${prefix}.${key}` : key;
     if (value === null || typeof value !== 'object') {
-      lines.push(`${path} = ${JSON.stringify(value)}`);
+      const note = FIELD_NOTES[key]?.(value);
+      lines.push(`${path} = ${JSON.stringify(value)}${note ? ` — ${note}` : ''}`);
     } else if (Array.isArray(value)) {
       // Relationship arrays are lists of {type,id}; summarize as ids.
       const ids = value
@@ -72,9 +180,12 @@ function summarizeBody(body: unknown, lines: string[], prefix = ''): void {
         lines.push(`${path} = ${JSON.stringify(value).slice(0, 100)}`);
       }
     } else if ('type' in (value as any) && 'id' in (value as any)) {
-      lines.push(`${path} → ${(value as any).type}/${(value as any).id}`);
+      const label = labels?.get(`${(value as any).type}/${(value as any).id}`);
+      lines.push(
+        `${path} → ${(value as any).type}/${(value as any).id}${label ? ` — "${label}"` : ''}`
+      );
     } else {
-      summarizeBody(value, lines, path);
+      summarizeBody(value, lines, path, labels);
     }
   }
 }
@@ -100,14 +211,18 @@ function countTerritories(body: unknown): number {
 
 /**
  * Builds the impact preview shown in the confirmation prompt (and used by
- * --dry-run). Pure — unit-tested without a client.
+ * --dry-run). When an http reader is provided, opaque reference ids in the
+ * body are resolved to human labels (best-effort): a price-point id becomes
+ * "Price: 99.99 TRY (TUR)", a subscription id becomes the product name — so
+ * the user sees WHAT they are confirming, not a base64 blob.
  */
-export function buildWritePreview(
+export async function buildWritePreview(
   toolName: string,
   op: PreviewableOp,
   args: Record<string, unknown>,
-  account?: string
-): WritePreview {
+  account?: string,
+  http?: RefReader
+): Promise<WritePreview> {
   const risk = (op.risk ?? 'low') as RiskLevel;
   const strong = STRONG_CONFIRM_LEVELS.has(risk);
 
@@ -125,8 +240,17 @@ export function buildWritePreview(
 
   const body = (args.body as any)?.data;
   if (body) {
+    const labels = http ? await resolveBodyRefs(http, body) : new Map<string, string>();
+
+    // The two labels that answer "what am I approving?" get their own lines.
+    for (const [key, label] of labels) {
+      if (key.startsWith('subscriptions/')) lines.push(`Product:    ${label}`);
+      else if (key.startsWith('apps/')) lines.push(`App:        ${label}`);
+      else if (key.startsWith('subscriptionPricePoints/')) lines.push(`Price:      ${label}`);
+    }
+
     const changes: string[] = [];
-    summarizeBody(body, changes);
+    summarizeBody(body, changes, '', labels);
     if (changes.length) {
       lines.push('Changes:');
       for (const c of changes.slice(0, MAX_CHANGE_LINES)) lines.push(`  ${c}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,12 @@ import { TokenProvider } from './core/jwt.js';
 import { AscHttpClient } from './core/http.js';
 import { ToolRegistry, DEFAULT_DOMAINS, type McpToolDefinition } from './core/registry.js';
 import { AscApiError } from './core/errors.js';
-import { confirmWrite, buildWritePreview, type WriteConfirmer } from './core/confirm.js';
+import {
+  confirmWrite,
+  buildWritePreview,
+  resolveBodyRefs,
+  type WriteConfirmer,
+} from './core/confirm.js';
 import type { ServerConfig } from './core/config.js';
 import { META_TOOLS, META_TOOL_NAMES, executeMetaTool } from './tools/meta.js';
 import { REVIEWS_AI_TOOLS, REVIEWS_AI_TOOL_NAMES, executeReviewsAiTool } from './tools/reviews-ai.js';
@@ -165,8 +170,8 @@ export function createServer(config: ServerConfig, profile?: Profile): Server {
       if (config.confirmWrites && !config.dryRun && writeToolNames.has(name)) {
         const op = registry.get(name);
         const preview = op
-          ? buildWritePreview(name, op, args, config.credentials.keyId)
-          : buildWritePreview(
+          ? await buildWritePreview(name, op, args, config.credentials.keyId, http)
+          : await buildWritePreview(
               name,
               // StoreKit tools live outside the spec; renewal-date extension is
               // the one that moves money.
@@ -250,6 +255,14 @@ export function createServer(config: ServerConfig, profile?: Profile): Server {
         result = await storekit.execute(name, args);
       } else {
         result = await registry.execute(name, args, http);
+        // Dry-run rehearsals get the same human translation as the live
+        // confirmation prompt, so the rehearsal shows what the real run would.
+        if ((result as any)?.dryRun === true && args.body !== undefined) {
+          const labels = await resolveBodyRefs(http, (args.body as any)?.data);
+          if (labels.size) {
+            (result as any).humanReadable = Object.fromEntries(labels);
+          }
+        }
         // Apple payloads are mostly URL noise the model never follows; strip
         // it and cap the size so one listing can't flood the context window.
         if (process.env.ASC_KEEP_RAW_RESPONSES !== '1') {

--- a/tests/risk.test.ts
+++ b/tests/risk.test.ts
@@ -58,8 +58,8 @@ describe('buildWritePreview', () => {
     },
   };
 
-  it('shows operation, changes, risk and typed-confirm instruction', () => {
-    const preview = buildWritePreview('subscription_prices__create', op, args, 'ABCD123456');
+  it('shows operation, changes, risk and typed-confirm instruction', async () => {
+    const preview = await buildWritePreview('subscription_prices__create', op, args, 'ABCD123456');
     expect(preview.strong).toBe(true);
     expect(preview.message).toContain('REVENUE-level write');
     expect(preview.message).toContain('POST /v1/subscriptionPrices');
@@ -68,8 +68,8 @@ describe('buildWritePreview', () => {
     expect(preview.message).toContain('Type CONFIRM');
   });
 
-  it('shows the target id and territory count', () => {
-    const preview = buildWritePreview(
+  it('shows the target id and territory count', async () => {
+    const preview = await buildWritePreview(
       'subscription_plan_availabilities__create',
       { method: 'POST', path: '/v1/subscriptionPlanAvailabilities/{id}', risk: 'revenue' },
       {
@@ -94,14 +94,99 @@ describe('buildWritePreview', () => {
     expect(preview.message).toContain('Territories in request: 3');
   });
 
-  it('keeps a checkbox (not typed confirm) for low-stakes writes', () => {
-    const preview = buildWritePreview(
+  it('keeps a checkbox (not typed confirm) for low-stakes writes', async () => {
+    const preview = await buildWritePreview(
       'beta_groups__create',
       { method: 'POST', path: '/v1/betaGroups', risk: 'low' },
       {}
     );
     expect(preview.strong).toBe(false);
     expect(preview.message).not.toContain('Type CONFIRM');
+  });
+});
+
+describe('preview reference resolution (AI-202)', () => {
+  const pricePointId = 'eyJzIjoiNjYzOTU5OTk5OSIsInQiOiJUVVIiLCJwIjoiMTAxNDcifQ';
+  const priceArgs = {
+    body: {
+      data: {
+        type: 'subscriptionPrices',
+        attributes: { preserveCurrentPrice: false },
+        relationships: {
+          subscription: { data: { type: 'subscriptions', id: '6639599999' } },
+          subscriptionPricePoint: {
+            data: { type: 'subscriptionPricePoints', id: pricePointId },
+          },
+        },
+      },
+    },
+  };
+  const op = { method: 'POST', path: '/v1/subscriptionPrices', risk: 'revenue' };
+
+  function fakeHttp() {
+    return {
+      get: vi.fn(async (path: string) => {
+        if (path.includes('/subscriptionPricePoints/')) {
+          return {
+            data: {
+              attributes: { customerPrice: '99.99' },
+              relationships: { territory: { data: { type: 'territories', id: 'TUR' } } },
+            },
+            included: [{ type: 'territories', id: 'TUR', attributes: { currency: 'TRY' } }],
+          };
+        }
+        if (path.includes('/subscriptions/')) {
+          return {
+            data: { attributes: { name: 'ask quran base 1week', productId: 'askquran.base.1week' } },
+          };
+        }
+        return {};
+      }),
+    };
+  }
+
+  it('translates opaque ids into Product and Price lines', async () => {
+    const preview = await buildWritePreview(
+      'subscription_prices__create',
+      op,
+      priceArgs,
+      'milowda',
+      fakeHttp()
+    );
+    expect(preview.message).toContain('Price:      99.99 TRY (TUR)');
+    expect(preview.message).toContain('Product:    ask quran base 1week (askquran.base.1week)');
+    // The relationship line carries the label inline too.
+    expect(preview.message).toContain('— "ask quran base 1week (askquran.base.1week)"');
+  });
+
+  it('spells out preserveCurrentPrice instead of showing a bare flag', async () => {
+    const preview = await buildWritePreview('x', op, priceArgs, undefined, fakeHttp());
+    expect(preview.message).toContain('WILL be moved to the new price');
+  });
+
+  it('falls back to raw ids when resolution fails — display only, never blocking', async () => {
+    const failing = { get: vi.fn().mockRejectedValue(new Error('offline')) };
+    const preview = await buildWritePreview('x', op, priceArgs, undefined, failing);
+    expect(preview.message).toContain(`subscriptionPricePoints/${pricePointId}`);
+    expect(preview.message).not.toContain('Price:');
+  });
+
+  it('caps reference lookups at 4 per preview', async () => {
+    const http = fakeHttp();
+    const many = {
+      body: {
+        data: {
+          relationships: Object.fromEntries(
+            Array.from({ length: 8 }, (_, i) => [
+              `rel${i}`,
+              { data: { type: 'subscriptions', id: `id-${i}` } },
+            ])
+          ),
+        },
+      },
+    };
+    await buildWritePreview('x', op, many, undefined, http);
+    expect(http.get.mock.calls.length).toBeLessThanOrEqual(4);
   });
 });
 


### PR DESCRIPTION
The live test showed a revenue confirmation whose only meaningful data — the
new price and territory — was locked inside a base64 price-point id. The user
typed CONFIRM without being able to see what they were confirming.

- Reference resolution (resolveBodyRefs): {type,id} pairs in the write body
  are resolved to human labels with at most 4 GET calls per preview —
  subscriptionPricePoints (customerPrice + currency + territory, one call via
  include=territory), subscriptions (name + productId), apps (name +
  bundleId), betaGroups (name). The prompt now leads with
  "Product: ask quran base 1week (askquran.base.1week)" and
  "Price: 99.99 TRY (TUR)", and relationship lines carry the label inline.
  Resolution is display-only and best-effort: a failed lookup leaves the raw
  id and never blocks or alters the write.
- FIELD_NOTES: meaning-heavy fields are spelled out —
  preserveCurrentPrice=false renders as "⚠ Existing subscribers WILL be moved
  to the new price." (true: "keep their current price"). The issue's
  "(agent default)" marker is not implementable server-side — the MCP server
  never sees the user's prompt — so these fields are unconditionally
  emphasized instead.
- Dry-run parity: a dry-run response carries the same resolved labels as
  humanReadable, so a rehearsal shows what the real confirmation would.

buildWritePreview is async now (takes an optional http reader); 4 new tests
cover translation, the heavy-field note, failed-lookup fallback and the
4-lookup cap. 169 passing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
