### PR TITLE
feat: one-call subscription price change — pricing macro (AI-203)

### DIFF
--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -14,6 +14,8 @@ export interface Profile {
   storekit?: boolean;
   /** AI-assisted review tools (triage, drafts, briefing). */
   reviewsAi?: boolean;
+  /** One-call pricing macros (set a subscription price in one step). */
+  pricing?: boolean;
 }
 
 export const PROFILES: Profile[] = [
@@ -37,6 +39,7 @@ export const PROFILES: Profile[] = [
     domains: ['subscriptions', 'iap', 'pricing'],
     description: 'Money: subscriptions, in-app purchases, offers, app pricing, StoreKit 2 transactions.',
     storekit: true,
+    pricing: true,
   },
   {
     name: 'marketing',

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,12 @@ import type { ServerConfig } from './core/config.js';
 import { META_TOOLS, META_TOOL_NAMES, executeMetaTool } from './tools/meta.js';
 import { REVIEWS_AI_TOOLS, REVIEWS_AI_TOOL_NAMES, executeReviewsAiTool } from './tools/reviews-ai.js';
 import { STOREKIT_TOOLS, STOREKIT_TOOL_NAMES, StoreKitService } from './storekit/index.js';
+import {
+  PRICING_TOOLS,
+  PRICING_TOOL_NAMES,
+  executePricingTool,
+  buildPricingPreview,
+} from './tools/pricing.js';
 import { SPEC_VERSION } from './generated/operations.js';
 import { GATEWAY_OPERATIONS, profileForDomain, registerCommand, type Profile } from './profiles.js';
 import {
@@ -91,6 +97,7 @@ export function createServer(config: ServerConfig, profile?: Profile): Server {
   }
 
   const reviewsAiWanted = profile ? Boolean(profile.reviewsAi) : true;
+  const pricingWanted = (profile ? Boolean(profile.pricing) : true) && !config.readOnly;
 
   const server = new Server(
     { name: profile ? `asc-${profile.name}` : 'app-store-connect-mcp', version: VERSION },
@@ -107,6 +114,9 @@ export function createServer(config: ServerConfig, profile?: Profile): Server {
     for (const t of STOREKIT_TOOLS) {
       if (t.annotations?.readOnlyHint !== true) writeToolNames.add(t.name);
     }
+  }
+  if (pricingWanted) {
+    for (const t of PRICING_TOOLS) writeToolNames.add(t.name);
   }
 
   const confirmer: WriteConfirmer = {
@@ -134,6 +144,7 @@ export function createServer(config: ServerConfig, profile?: Profile): Server {
     const tools: McpToolDefinition[] = [
       ...META_TOOLS,
       ...(reviewsAiWanted && clientSupportsSampling() ? REVIEWS_AI_TOOLS : []),
+      ...(pricingWanted ? PRICING_TOOLS : []),
       ...registry.listTools(),
     ];
 
@@ -169,7 +180,10 @@ export function createServer(config: ServerConfig, profile?: Profile): Server {
 
       if (config.confirmWrites && !config.dryRun && writeToolNames.has(name)) {
         const op = registry.get(name);
-        const preview = op
+        const preview = PRICING_TOOL_NAMES.has(name)
+          ? // Macro parameters are already human language — no lookups needed.
+            { message: buildPricingPreview(args), strong: true }
+          : op
           ? await buildWritePreview(name, op, args, config.credentials.keyId, http)
           : await buildWritePreview(
               name,
@@ -232,6 +246,8 @@ export function createServer(config: ServerConfig, profile?: Profile): Server {
               }
             : undefined,
         });
+      } else if (pricingWanted && PRICING_TOOL_NAMES.has(name)) {
+        result = await executePricingTool(name, args, { http, dryRun: config.dryRun });
       } else if (reviewsAiWanted && REVIEWS_AI_TOOL_NAMES.has(name)) {
         result = await executeReviewsAiTool(name, args, {
           server,

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -44,7 +44,7 @@ function profileToolCount(p: Profile): number {
     includeDeprecated: false,
     extraOperations: GATEWAY_OPERATIONS,
   });
-  return registry.size + 3 + (p.reviewsAi ? 3 : 0); // + meta tools (+ reviews-ai)
+  return registry.size + 3 + (p.reviewsAi ? 3 : 0) + (p.pricing ? 1 : 0); // + meta (+ reviews-ai, + pricing macros)
 }
 
 /** One compact picker row: `app-info(115) ~17k · names, bundle ids, …` */

--- a/src/tools/pricing.ts
+++ b/src/tools/pricing.ts
@@ -1,0 +1,262 @@
+/**
+ * Pricing macro tools — the one-call answer to a multi-call flow.
+ *
+ * Changing a subscription price through the raw 1:1 tools takes four reads
+ * (app → subscription groups → subscriptions → 842 price points) before the
+ * one write, which is why agents preferred single-call competitors. This layer
+ * does the resolution internally and never shows the price-point haystack to
+ * the model. The raw tools stay untouched — this is an opt-in layer on top,
+ * like reviews-ai.
+ *
+ * Every input is human-friendly (app name/bundle id, product id, "99.99") and
+ * preserve_current_price is a REQUIRED parameter: the agent has to surface
+ * that customer-facing decision instead of silently picking a default.
+ */
+import type { McpToolDefinition } from '../core/registry.js';
+import type { AscHttpClient } from '../core/http.js';
+import { AscApiError } from '../core/errors.js';
+
+export const PRICING_TOOLS: McpToolDefinition[] = [
+  {
+    name: 'pricing__set_subscription_price',
+    description:
+      'Change or set a subscription price in one territory (country) in a single step. ' +
+      'Give it the app (name, bundle ID or Apple ID), the subscription (product ID or ' +
+      'name), the territory (e.g. TUR, USA) and the price (e.g. "99.99") — it resolves ' +
+      'the app, subscription and Apple price point internally and performs the one ' +
+      'write. Use this instead of chaining apps__list / subscription_groups / ' +
+      'price_points calls when the goal is simply "set/raise/lower the price".',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        app: {
+          type: 'string',
+          description: 'App name, bundle ID (com.example.app) or numeric Apple ID.',
+        },
+        subscription: {
+          type: 'string',
+          description: 'Subscription product ID (e.g. com.example.pro.monthly) or its reference name.',
+        },
+        territory: {
+          type: 'string',
+          description: 'Territory (country) code, e.g. TUR, USA, DEU.',
+        },
+        price: {
+          type: 'string',
+          description: 'Customer price in the territory\'s currency, e.g. "99.99". Must match an Apple price point exactly; if it does not exist, the nearest available prices are suggested.',
+        },
+        preserve_current_price: {
+          type: 'boolean',
+          description:
+            'REQUIRED decision about existing subscribers: true = they keep their current ' +
+            'price; false = they WILL be moved to the new price. Ask the user if unsure.',
+        },
+        start_date: {
+          type: 'string',
+          description: 'Optional start date (YYYY-MM-DD). Omit to apply as soon as possible.',
+        },
+      },
+      required: ['app', 'subscription', 'territory', 'price', 'preserve_current_price'],
+    },
+    annotations: { readOnlyHint: false, idempotentHint: false },
+  },
+];
+
+export const PRICING_TOOL_NAMES = new Set(PRICING_TOOLS.map((t) => t.name));
+
+export interface PricingContext {
+  http: AscHttpClient;
+  /** Mirrors --dry-run: resolve everything, write nothing. */
+  dryRun?: boolean;
+}
+
+/** Normalises "99,99" / " 99.99 " to a canonical dotted string. */
+export function normalizePrice(input: string): string {
+  return input.trim().replace(',', '.');
+}
+
+async function resolveApp(http: AscHttpClient, app: string): Promise<{ id: string; name: string }> {
+  const wanted = app.trim();
+  if (/^\d+$/.test(wanted)) {
+    const res: any = await http.get(`/v1/apps/${encodeURIComponent(wanted)}`);
+    if (!res?.data) throw new AscApiError(`No app with Apple ID ${wanted}.`, 0);
+    return { id: res.data.id, name: res.data.attributes?.name ?? wanted };
+  }
+  if (wanted.includes('.')) {
+    const res: any = await http.get('/v1/apps', { 'filter[bundleId]': wanted });
+    const hit = res?.data?.[0];
+    if (!hit) throw new AscApiError(`No app with bundle ID "${wanted}".`, 0);
+    return { id: hit.id, name: hit.attributes?.name ?? wanted };
+  }
+  const res: any = await http.get('/v1/apps', { limit: 200 });
+  const needle = wanted.toLowerCase();
+  const hits = (res?.data ?? []).filter((a: any) =>
+    String(a.attributes?.name ?? '').toLowerCase().includes(needle)
+  );
+  if (hits.length === 1) return { id: hits[0].id, name: hits[0].attributes.name };
+  if (hits.length === 0) throw new AscApiError(`No app matching "${wanted}".`, 0);
+  throw new AscApiError(
+    `App name "${wanted}" is ambiguous: ${hits.map((h: any) => h.attributes.name).join(' | ')}. ` +
+      `Use the bundle ID or Apple ID.`,
+    0
+  );
+}
+
+async function resolveSubscription(
+  http: AscHttpClient,
+  appId: string,
+  subscription: string
+): Promise<{ id: string; name: string; productId: string }> {
+  const groups: any = await http.get(`/v1/apps/${encodeURIComponent(appId)}/subscriptionGroups`, {
+    include: 'subscriptions',
+    limit: 50,
+  });
+  const subs = (groups?.included ?? []).filter((i: any) => i.type === 'subscriptions');
+  const wanted = subscription.trim().toLowerCase();
+  const match =
+    subs.find((s: any) => String(s.attributes?.productId ?? '').toLowerCase() === wanted) ??
+    subs.find((s: any) => String(s.attributes?.name ?? '').toLowerCase() === wanted) ??
+    subs.find((s: any) => String(s.attributes?.name ?? '').toLowerCase().includes(wanted));
+  if (!match) {
+    const available = subs
+      .map((s: any) => `${s.attributes?.productId} ("${s.attributes?.name}")`)
+      .join(', ');
+    throw new AscApiError(
+      `No subscription matching "${subscription}" in this app. Available: ${available || 'none'}.`,
+      0
+    );
+  }
+  return {
+    id: match.id,
+    name: match.attributes?.name ?? subscription,
+    productId: match.attributes?.productId ?? '',
+  };
+}
+
+async function resolvePricePoint(
+  http: AscHttpClient,
+  subscriptionId: string,
+  territory: string,
+  price: string
+): Promise<{ id: string; customerPrice: string }> {
+  const target = Number(normalizePrice(price));
+  // The haystack (800+ points per territory) stays inside this function; the
+  // model never sees it.
+  const { items } = await http.collect<any>(
+    `/v1/subscriptions/${encodeURIComponent(subscriptionId)}/pricePoints`,
+    { 'filter[territory]': territory.toUpperCase(), limit: 200 },
+    10
+  );
+  const points = items.map((p: any) => ({
+    id: String(p.id),
+    customerPrice: String(p.attributes?.customerPrice ?? ''),
+    value: Number(p.attributes?.customerPrice),
+  }));
+  const exact = points.find((p) => p.value === target);
+  if (exact) return exact;
+
+  const sorted = points.filter((p) => Number.isFinite(p.value)).sort((a, b) => a.value - b.value);
+  const below = [...sorted].reverse().find((p) => p.value < target);
+  const above = sorted.find((p) => p.value > target);
+  const nearest = [below?.customerPrice, above?.customerPrice].filter(Boolean).join(', ');
+  throw new AscApiError(
+    `${normalizePrice(price)} is not an available Apple price point for this subscription in ` +
+      `${territory.toUpperCase()}${nearest ? `; nearest available: ${nearest}` : ''}. ` +
+      `Apple only allows prices from its fixed tiers.`,
+    0
+  );
+}
+
+/**
+ * Human-language preview for the confirmation prompt — the parameters already
+ * carry the meaning, no reference resolution needed.
+ */
+export function buildPricingPreview(args: Record<string, unknown>): string {
+  const preserve = args.preserve_current_price === true;
+  return [
+    `Heimdall is about to change a subscription price — a REVENUE-level write.`,
+    '',
+    `App:          ${String(args.app ?? '?')}`,
+    `Subscription: ${String(args.subscription ?? '?')}`,
+    `New price:    ${normalizePrice(String(args.price ?? '?'))} (${String(args.territory ?? '?').toUpperCase()})`,
+    ...(args.start_date ? [`Starts:       ${String(args.start_date)}`] : []),
+    preserve
+      ? `Subscribers:  existing subscribers keep their current price.`
+      : `Subscribers:  ⚠ existing subscribers WILL be moved to the new price.`,
+    '',
+    'Type CONFIRM in the field below to proceed.',
+  ].join('\n');
+}
+
+export async function executePricingTool(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: PricingContext
+): Promise<unknown> {
+  if (name !== 'pricing__set_subscription_price') {
+    throw new Error(`Unknown pricing tool: ${name}`);
+  }
+
+  for (const field of ['app', 'subscription', 'territory', 'price'] as const) {
+    if (!args[field] || typeof args[field] !== 'string') {
+      throw new AscApiError(`"${field}" is required.`, 0);
+    }
+  }
+  if (typeof args.preserve_current_price !== 'boolean') {
+    throw new AscApiError(
+      '"preserve_current_price" is required: true keeps existing subscribers on their ' +
+        'current price, false moves them to the new price. Ask the user which they want.',
+      0
+    );
+  }
+
+  const app = await resolveApp(ctx.http, String(args.app));
+  const sub = await resolveSubscription(ctx.http, app.id, String(args.subscription));
+  const point = await resolvePricePoint(
+    ctx.http,
+    sub.id,
+    String(args.territory),
+    String(args.price)
+  );
+
+  const body = {
+    data: {
+      type: 'subscriptionPrices',
+      attributes: {
+        preserveCurrentPrice: args.preserve_current_price,
+        ...(args.start_date ? { startDate: String(args.start_date) } : {}),
+      },
+      relationships: {
+        subscription: { data: { type: 'subscriptions', id: sub.id } },
+        subscriptionPricePoint: { data: { type: 'subscriptionPricePoints', id: point.id } },
+      },
+    },
+  };
+
+  const resolved = {
+    app: `${app.name} (${app.id})`,
+    subscription: `${sub.name} (${sub.productId})`,
+    price: `${point.customerPrice} (${String(args.territory).toUpperCase()})`,
+    preserveCurrentPrice: args.preserve_current_price,
+    ...(args.start_date ? { startDate: String(args.start_date) } : {}),
+  };
+
+  if (ctx.dryRun) {
+    return {
+      dryRun: true,
+      note: 'Dry-run mode: the price change was fully resolved but NOT sent to Apple.',
+      resolved,
+      wouldSend: { method: 'POST', path: '/v1/subscriptionPrices', body },
+      risk: 'revenue',
+    };
+  }
+
+  await ctx.http.post('/v1/subscriptionPrices', body);
+  return {
+    ok: true,
+    changed: resolved,
+    note:
+      'Price change submitted. Apple applies it per its own schedule; check ' +
+      'subscriptions__prices__list to see current and scheduled prices.',
+  };
+}

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  PRICING_TOOLS,
+  executePricingTool,
+  buildPricingPreview,
+  normalizePrice,
+  type PricingContext,
+} from '../src/tools/pricing.js';
+
+/** Fake http covering the whole resolution chain for one app. */
+function fakeHttp() {
+  const get = vi.fn(async (path: string, query?: any) => {
+    if (path === '/v1/apps' && query?.['filter[bundleId]']) {
+      return { data: [{ id: '6636549188', attributes: { name: 'Ask Quran', bundleId: query['filter[bundleId]'] } }] };
+    }
+    if (path === '/v1/apps') {
+      return {
+        data: [
+          { id: '6636549188', attributes: { name: 'Ask Quran: AI Islam Companion' } },
+          { id: '6502901728', attributes: { name: 'AI Caption Generator: Postmate' } },
+        ],
+      };
+    }
+    if (path.startsWith('/v1/apps/6636549188/subscriptionGroups')) {
+      return {
+        data: [{ type: 'subscriptionGroups', id: 'g1' }],
+        included: [
+          { type: 'subscriptions', id: '6639599999', attributes: { name: 'ask quran base 1week', productId: 'askquran.base.1week' } },
+          { type: 'subscriptions', id: '6639600093', attributes: { name: 'ask quran base 1month', productId: 'askquran.base.1month' } },
+        ],
+      };
+    }
+    if (path.startsWith('/v1/apps/6636549188')) {
+      return { data: { id: '6636549188', attributes: { name: 'Ask Quran: AI Islam Companion' } } };
+    }
+    if (path.startsWith('/v1/subscriptions/6639599999/pricePoints')) {
+      return {
+        data: [
+          { id: 'pp-94', attributes: { customerPrice: '94.99' } },
+          { id: 'pp-99', attributes: { customerPrice: '99.99' } },
+          { id: 'pp-104', attributes: { customerPrice: '104.99' } },
+        ],
+        links: {},
+      };
+    }
+    return {};
+  });
+  const collect = vi.fn(async (path: string, query?: any) => {
+    const res: any = await get(path, query);
+    return { items: res?.data ?? [], pagesFetched: 1, hasMore: false, nextUrl: undefined };
+  });
+  const post = vi.fn(async () => ({ data: { id: 'created' } }));
+  return { get, collect, post };
+}
+
+function ctx(overrides: Partial<PricingContext> = {}): PricingContext & { http: any } {
+  return { http: fakeHttp(), ...overrides } as any;
+}
+
+const goodArgs = {
+  app: '6636549188',
+  subscription: 'askquran.base.1week',
+  territory: 'tur',
+  price: '99,99', // comma on purpose — must normalize
+  preserve_current_price: false,
+};
+
+describe('pricing__set_subscription_price', () => {
+  it('resolves app, subscription and price point, then performs the one write', async () => {
+    const c = ctx();
+    const result: any = await executePricingTool('pricing__set_subscription_price', goodArgs, c);
+
+    expect(result.ok).toBe(true);
+    expect(result.changed.subscription).toBe('ask quran base 1week (askquran.base.1week)');
+    expect(result.changed.price).toBe('99.99 (TUR)');
+
+    const [path, body] = c.http.post.mock.calls[0];
+    expect(path).toBe('/v1/subscriptionPrices');
+    expect(body.data.relationships.subscriptionPricePoint.data.id).toBe('pp-99');
+    expect(body.data.attributes.preserveCurrentPrice).toBe(false);
+  });
+
+  it('resolves the app by bundle ID and by (unique) name', async () => {
+    const c1 = ctx();
+    await executePricingTool(
+      'pricing__set_subscription_price',
+      { ...goodArgs, app: 'com.milowda.askquranai' },
+      c1
+    );
+    expect(c1.http.post).toHaveBeenCalled();
+
+    const c2 = ctx();
+    await executePricingTool('pricing__set_subscription_price', { ...goodArgs, app: 'ask quran' }, c2);
+    expect(c2.http.post).toHaveBeenCalled();
+  });
+
+  it('suggests the nearest available prices when the exact tier does not exist', async () => {
+    const c = ctx();
+    await expect(
+      executePricingTool('pricing__set_subscription_price', { ...goodArgs, price: '97.50' }, c)
+    ).rejects.toThrow(/nearest available: 94\.99, 99\.99/);
+    expect(c.http.post).not.toHaveBeenCalled();
+  });
+
+  it('lists the available subscriptions when the product is not found', async () => {
+    const c = ctx();
+    await expect(
+      executePricingTool('pricing__set_subscription_price', { ...goodArgs, subscription: 'nope' }, c)
+    ).rejects.toThrow(/askquran\.base\.1week/);
+  });
+
+  it('refuses to run without an explicit preserve_current_price decision', async () => {
+    const { preserve_current_price: _omitted, ...args } = goodArgs;
+    await expect(
+      executePricingTool('pricing__set_subscription_price', args, ctx())
+    ).rejects.toThrow(/preserve_current_price/);
+    // And the schema enforces it too, so the model is told upfront.
+    expect(PRICING_TOOLS[0].inputSchema.required).toContain('preserve_current_price');
+  });
+
+  it('dry-run resolves everything but never POSTs', async () => {
+    const c = ctx({ dryRun: true });
+    const result: any = await executePricingTool('pricing__set_subscription_price', goodArgs, c);
+
+    expect(result.dryRun).toBe(true);
+    expect(result.resolved.price).toBe('99.99 (TUR)');
+    expect(result.wouldSend.body.data.relationships.subscriptionPricePoint.data.id).toBe('pp-99');
+    expect(c.http.post).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildPricingPreview', () => {
+  it('is human language with the subscriber consequence spelled out', () => {
+    const msg = buildPricingPreview(goodArgs);
+    expect(msg).toContain('REVENUE-level write');
+    expect(msg).toContain('New price:    99.99 (TUR)');
+    expect(msg).toContain('WILL be moved to the new price');
+    expect(msg).toContain('Type CONFIRM');
+  });
+
+  it('shows the keep-price wording when preserving', () => {
+    const msg = buildPricingPreview({ ...goodArgs, preserve_current_price: true });
+    expect(msg).toContain('keep their current price');
+  });
+});
+
+describe('normalizePrice', () => {
+  it('accepts comma decimals and padding', () => {
+    expect(normalizePrice(' 99,99 ')).toBe('99.99');
+    expect(normalizePrice('4.99')).toBe('4.99');
+  });
+});


### PR DESCRIPTION
Live test: the agent picked a competitor MCP because changing a price through
the raw tools took four reads (app → groups → subscriptions → 842 price
points) before the one write; the shortest path won.

pricing__set_subscription_price(app, subscription, territory, price,
preserve_current_price, start_date?) collapses the flow to a single call:

- Resolution happens internally: app by name/bundle id/Apple id (ambiguous
  names error with candidates), subscription by product id or name (misses
  list what IS available), and the price point by exact customer price within
  the territory — the 800+-point haystack never reaches the model. A price
  that isn't an Apple tier fails with the nearest available prices.
- preserve_current_price is a REQUIRED parameter with both consequences in
  its description — the agent must surface the existing-subscribers decision
  instead of silently defaulting it (closing the AI-202 gap at the source).
- One write, one confirmation: the tool is registered as a revenue-level
  write with typed CONFIRM, and its preview is pure human language ("New
  price: 99.99 (TUR)", subscriber consequence spelled out) — the parameters
  already carry the meaning, no reference lookups needed.
- --dry-run resolves the full chain and returns { resolved, wouldSend }
  without POSTing.

The 1:1 wrappers stay untouched — this is an opt-in layer (reviews-ai
pattern) on the monetization profile and the combined server, hidden in
read-only mode. 11 new tests cover the resolution chain, nearest-price
suggestions, the required decision, dry-run and the preview. 178 passing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
