### PR TITLE
docs: add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ## What changes, and why
 
-<!-- Tek cumlede: ne degisti, neden gerekti. -->
+<!-- Tek cümlede: ne değişti, neden gerekti. -->
 
 ## Related issue
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- One concern per PR - see .github/CONTRIBUTING.md -->
+
+## What changes, and why
+
+<!-- Tek cumlede: ne degisti, neden gerekti. -->
+
+## Related issue
+
+Closes #
+
+## Checklist
+
+- [ ] `npm test` and `npm run typecheck` pass
+- [ ] Generator touched? Regenerated `src/generated/` is committed and the tool count change is noted below
+- [ ] Descriptions or tool surface touched? `npm run ax:report` was run and any improved ceiling in `tests/ax-audit.test.ts` was lowered
+- [ ] Docs updated if behaviour changed
+- [ ] No credentials, private keys, or real App Store Connect identifiers in the diff
+
+## Tool count / AX impact
+
+<!-- e.g. 982 -> 984, or description debt 41% -> 38%. No change is a valid answer. -->
+
+## How this was verified
+
+<!-- Which command, which MCP client, which scenario. -->


### PR DESCRIPTION
Mirrors the rules already in CONTRIBUTING.md: one concern per PR, tests and typecheck must pass, regenerated output committed, AX ceilings updated, no credentials in the diff.