### PR TITLE
ci: add one aggregate check for branch protection to require

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,14 @@ jobs:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
+
+  # One check to require in branch protection, so the matrix can change
+  # without the ruleset going stale.
+  ci-ok:
+    if: always()
+    needs: [test, smoke, dependency-review]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if a required job did not succeed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
Requiring test (20), test (22), test (24) by name means the ruleset breaks the day the matrix changes: the named check never arrives and the PR waits forever. ci-ok depends on the real jobs and is the only name the ruleset needs to know. It fails on failure or cancellation and tolerates skips, so dependency-review not running on push does not block anything.