### PR TITLE
chore: patch postcss, and stop Scorecard from repeating itself

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,9 +7,10 @@ on:
   branch_protection_rule:
   schedule:
     - cron: '31 4 * * 1' # Mondays, 04:31 UTC
-  push:
-    branches: [main]
   workflow_dispatch:
+# No push trigger: the score measures repository practices, not the diff, so a
+# run per merge only refiles the same alerts. Weekly is enough; use
+# workflow_dispatch to score a change on demand.
 
 permissions: read-all
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3138,9 +3138,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## What

- `postcss` 8.5.20 → 8.5.25 in the lockfile, closing [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp). Dev-only (`vitest → vite → postcss`), never shipped.
- Scorecard drops its `push: branches: [main]` trigger.

## Why the trigger goes

Scorecard scores repository practices, not the diff. Running it per merge refiled the same seven alerts — eight times today. The weekly cron and `workflow_dispatch` cover the same ground without the noise.

## Alerts dismissed alongside this

Five were closed as won't-fix, not silenced blindly:

| Alert | Reason |
| :--- | :--- |
| BranchProtection | Requiring approvers on a solo repo makes every PR unmergeable |
| CodeReview | 0/7 approved changesets — there is no second maintainer to approve |
| Maintained | "Repository created within the last 90 days" resolves on its own |
| Fuzzing | Deliberate omission for an API client |
| CIIBestPractices | Badge paperwork, not a defect |

Real findings still surface — `postcss` above was one of them.

## Checks

`npm audit` → 0 vulnerabilities. Typecheck, build and 338 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)