### PR TITLE
ci: drop the global npm install from the publish path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,27 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Node 24 for the npm it bundles, not for the runtime: trusted publishing
+      # (OIDC -> registry token exchange) needs npm >= 11.5, and Node 22 ships
+      # npm 10, which signs provenance but then PUTs without credentials while
+      # npm masks the rejection as a 404. Node 24 ships npm 11.17. The package
+      # itself still supports Node >= 20.19 — see engines in package.json.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      # The 404 npm returns for a too-old client says nothing about the cause,
+      # so name it here instead of at the publish step.
+      - name: Fail early if npm cannot do trusted publishing
+        run: |
+          node -e 'const v = require("child_process").execSync("npm --version").toString().trim();
+          const [a, b] = v.split(".").map(Number);
+          if (a < 11 || (a === 11 && b < 5)) {
+            console.error(`npm ${v} is too old for trusted publishing (need >= 11.5). Raise node-version above.`);
+            process.exit(1);
+          }
+          console.log(`npm ${v} supports trusted publishing.`);'
 
       - run: npm ci
 
@@ -34,11 +51,6 @@ jobs:
 
       - run: npm run build
       - run: npm test
-
-      # Trusted publishing (OIDC -> registry token exchange) needs npm >= 11.5;
-      # Node 22 ships npm 10, which signs provenance but then PUTs without
-      # credentials and npm masks the rejection as a 404.
-      - run: npm install -g npm@latest
 
       # --provenance publishes a signed attestation linking the tarball to this
       # repository, commit and workflow run.


### PR DESCRIPTION
Closes the last open Scorecard alert (#11, `PinnedDependencies` at `publish.yml:42`).

## What

`node-version` goes `22` → `24` in the publish job, and `npm install -g npm@latest` is deleted.

Node 24 ships npm 11.17, past the 11.5 that trusted publishing needs, so the global install has nothing left to do.

## Why remove rather than pin

That step was the last unpinned dependency in a job holding OIDC publish rights — `latest` meant whatever npm shipped that morning ran next to the token exchange. A global install cannot be pinned by hash, and pinning it to a version would trade the alert for a number that goes stale unnoticed. Removing the step retires both.

Node 24 is chosen for the npm it bundles, not for the runtime. The package still declares `engines: node >= 20.19` and CI still tests 20, 22 and 24.

## The guard

The removed step carried the constraint in its comment. A check now carries it instead:

```
npm 11.12.1 supports trusted publishing.
```

npm answers a too-old client with a bare 404 that names nothing — that masking is what made this expensive to diagnose the first time. The check fails at the top of the job and says which knob to turn.

Verified by extracting the step's script from the YAML and running it: passes on 11.12.1, and the comparison was checked at its boundaries (10.9.8 ✗, 11.4.9 ✗, 11.5.0 ✓, 11.17.0 ✓, 12.0.2 ✓).

## What is not verified

The publish job only runs on a `v*` tag, so this path stays untested until the next release. The two claims it rests on are checked: Node 24.19.0 bundles npm 11.17.0 per `nodejs.org/dist/index.json`, and the guard fails loudly if that ever stops being true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)