### PR TITLE
fix: bump fast-uri out of the host-confusion advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2196,9 +2196,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

`fast-uri` 3.1.4 → 3.1.5, closing [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — a backslash authority introducer lets a URI resolve to a different host than it reads as. High severity.

## Why this one is not like the postcss patch

That one was dev-only. This is a runtime dependency:

```
@erayendes/asc-mcp
`-- @modelcontextprotocol/sdk@1.30.0
  `-- ajv@8.20.0
    `-- fast-uri@3.1.4
```

ajv reaches fast-uri while resolving `$id` and `$ref` in JSON Schema. The schemas resolved here are our own generated tool definitions, not anything a caller supplies, so the practical exposure is narrow — but it ships, and the fix is one lockfile line.

## Note on the alert

Scorecard's `Vulnerabilities` alert had closed after the postcss patch and reopened on this. That is not a regression on our side: the advisory is newly published and landed on a tree that was clean an hour earlier.

## Checks

`npm audit` → 0 vulnerabilities. Typecheck clean, 338 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)