### PR TITLE
fix: check_entitlement was answering about the wrong product

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2469,9 +2469,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/src/storekit/index.ts
+++ b/src/storekit/index.ts
@@ -9,11 +9,43 @@
 import {
   AppStoreServerAPIClient,
   Environment,
+  ExtendReasonCode,
+  GetTransactionHistoryVersion,
+  Status,
+  type ExtendRenewalDateRequest,
+  type HistoryResponse,
+  type LastTransactionsItem,
+  type NotificationHistoryRequest,
+  type NotificationTypeV2,
+  type Order,
+  type ProductType,
+  type RefundHistoryResponse,
+  type StatusResponse,
+  type SubscriptionGroupIdentifierItem,
   type TransactionHistoryRequest,
 } from '@apple/app-store-server-library';
 import { readFileSync } from 'node:fs';
 import type { McpToolDefinition } from '../core/registry.js';
 import type { ServerConfig } from '../core/config.js';
+
+/**
+ * Reads one claim out of a JWS payload without verifying the signature.
+ *
+ * Apple signs these and we received them over TLS from an endpoint we
+ * authenticated to, so the claim is only as trustworthy as that channel —
+ * which is enough to filter our own response. Nothing here grants access;
+ * callers who need a verified payload should run it through the library's
+ * SignedDataVerifier.
+ */
+function jwsClaim(jws: string | undefined, claim: string): unknown {
+  const payload = jws?.split('.')[1];
+  if (payload === undefined) return undefined;
+  try {
+    return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))[claim];
+  } catch {
+    return undefined;
+  }
+}
 
 export const STOREKIT_TOOLS: McpToolDefinition[] = [
   {
@@ -266,22 +298,20 @@ export class StoreKitService {
         return { signedTransactionInfo: res.signedTransactionInfo };
       }
 
-      case 'storekit__get_subscription_statuses': {
-        const res = await client.getAllSubscriptionStatuses(
+      case 'storekit__get_subscription_statuses':
+        return client.getAllSubscriptionStatuses(
           args.transaction_id,
-          args.status
+          args.status as Status[] | undefined
         );
-        return res;
-      }
 
       case 'storekit__check_entitlement':
         return this.checkEntitlement(client, args);
 
       case 'storekit__get_refund_history': {
-        const items: unknown[] = [];
+        const items: string[] = [];
         let revision: string | null = null;
         for (let page = 0; page < 10; page++) {
-          const res: any = await client.getRefundHistory(
+          const res: RefundHistoryResponse = await client.getRefundHistory(
             args.transaction_id,
             revision
           );
@@ -301,13 +331,16 @@ export class StoreKitService {
       }
 
       case 'storekit__get_notification_history': {
-        const res = await client.getNotificationHistory(null, {
+        // notificationType is a string enum in the library; the inputSchema
+        // leaves it a free string, so this is the one place we take the
+        // caller's word for it.
+        const request: NotificationHistoryRequest = {
           startDate: args.start_date,
           endDate: args.end_date,
-          notificationType: args.notification_type,
+          notificationType: args.notification_type as NotificationTypeV2 | undefined,
           onlyFailures: args.only_failures,
-        } as any);
-        return res;
+        };
+        return client.getNotificationHistory(null, request);
       }
 
       case 'storekit__request_test_notification':
@@ -318,13 +351,15 @@ export class StoreKitService {
         if (!Number.isInteger(days) || days < 1 || days > 90) {
           throw new Error('extend_by_days must be an integer between 1 and 90.');
         }
+        const request: ExtendRenewalDateRequest = {
+          extendByDays: days,
+          extendReasonCode: (args.reason ??
+            ExtendReasonCode.CUSTOMER_SATISFACTION) as ExtendReasonCode,
+          requestIdentifier: args.request_identifier,
+        };
         return client.extendSubscriptionRenewalDate(
           args.original_transaction_id,
-          {
-            extendByDays: days,
-            extendReasonCode: args.reason ?? 1,
-            requestIdentifier: args.request_identifier,
-          } as any
+          request
         );
       }
 
@@ -337,23 +372,27 @@ export class StoreKitService {
     client: AppStoreServerAPIClient,
     args: Record<string, any>
   ): Promise<unknown> {
+    // sort and product_type are constrained to the library's enum values by
+    // this tool's inputSchema, so the casts narrow rather than widen.
     const request: TransactionHistoryRequest = {
-      sort: args.sort,
+      sort: args.sort as Order | undefined,
       productIds: args.product_id ? [args.product_id] : undefined,
-      productTypes: args.product_type ? [args.product_type] : undefined,
+      productTypes: args.product_type
+        ? [args.product_type as ProductType]
+        : undefined,
       revoked: args.revoked,
-    } as TransactionHistoryRequest;
+    };
 
     const maxPages = Math.max(1, Math.min(Number(args.max_pages ?? 5), 50));
     const transactions: string[] = [];
     let revision: string | null = null;
 
     for (let page = 0; page < maxPages; page++) {
-      const res: any = await client.getTransactionHistory(
+      const res: HistoryResponse = await client.getTransactionHistory(
         args.transaction_id,
         revision,
         request,
-        'v2' as any
+        GetTransactionHistoryVersion.V2
       );
       if (Array.isArray(res?.signedTransactions)) {
         transactions.push(...res.signedTransactions);
@@ -370,22 +409,32 @@ export class StoreKitService {
     client: AppStoreServerAPIClient,
     args: Record<string, any>
   ): Promise<unknown> {
-    const res: any = await client.getAllSubscriptionStatuses(
+    const res: StatusResponse = await client.getAllSubscriptionStatuses(
       args.transaction_id,
-      [1, 4] // Active and GracePeriod both grant access.
+      [Status.ACTIVE, Status.BILLING_GRACE_PERIOD] // Both grant access.
     );
 
-    const groups: any[] = res?.data ?? [];
-    const matching = args.product_id
-      ? groups.filter((g) =>
-          (g.lastTransactions ?? []).some(
-            (t: any) => t.originalTransactionId && g.subscriptionGroupIdentifier
-          )
-        )
+    const groups: SubscriptionGroupIdentifierItem[] = res.data ?? [];
+
+    // A group is named by its subscription group, not by product, and the
+    // product ID lives inside each transaction's signed payload — so narrowing
+    // to one product means reading that payload, and keeping only the groups
+    // that still hold a transaction afterwards.
+    const matching: SubscriptionGroupIdentifierItem[] = args.product_id
+      ? groups
+          .map((g) => ({
+            ...g,
+            lastTransactions: (g.lastTransactions ?? []).filter(
+              (t) => jwsClaim(t.signedTransactionInfo, 'productId') === args.product_id
+            ),
+          }))
+          .filter((g) => g.lastTransactions.length > 0)
       : groups;
 
-    const active = matching.flatMap((g) =>
-      (g.lastTransactions ?? []).filter((t: any) => t.status === 1 || t.status === 4)
+    const active: LastTransactionsItem[] = matching.flatMap((g) =>
+      (g.lastTransactions ?? []).filter(
+        (t) => t.status === Status.ACTIVE || t.status === Status.BILLING_GRACE_PERIOD
+      )
     );
 
     return {

--- a/tests/storekit.test.ts
+++ b/tests/storekit.test.ts
@@ -1,0 +1,152 @@
+/**
+ * StoreKit entitlement logic.
+ *
+ * `check_entitlement` answers "does this customer have access?", optionally
+ * narrowed to one product. The narrowing is the part worth pinning: a product
+ * ID is not on the subscription-group item, it is inside each transaction's
+ * signed payload, so a filter that never opens that payload silently answers
+ * about the wrong product.
+ */
+import { describe, expect, it } from 'vitest';
+import { StoreKitService } from '../src/storekit/index.js';
+import type { ServerConfig } from '../src/core/config.js';
+import type { StatusResponse } from '@apple/app-store-server-library';
+
+const config = {
+  credentials: {
+    keyId: 'KEYID00000',
+    issuerId: '00000000-0000-0000-0000-000000000000',
+    privateKey: '-----BEGIN PRIVATE KEY-----\\nnot-a-real-key\\n-----END PRIVATE KEY-----',
+  },
+  storekit: { bundleId: 'com.example.app', environment: 'Sandbox' },
+  readOnly: false,
+  confirmWrites: false,
+  allowUnconfirmedWrites: false,
+  includeDeprecated: false,
+} as ServerConfig;
+
+/** A JWS whose payload carries one product ID. Signature is never checked. */
+function signedTransaction(productId: string): string {
+  const payload = Buffer.from(JSON.stringify({ productId })).toString('base64url');
+  return `header.${payload}.signature`;
+}
+
+/** Stands in for the API client; only the one method under test is reached. */
+function stubClient(response: StatusResponse) {
+  return { getAllSubscriptionStatuses: async () => response } as never;
+}
+
+/** Two groups, each holding one active transaction for a different product. */
+const twoProducts: StatusResponse = {
+  data: [
+    {
+      subscriptionGroupIdentifier: 'group-pro',
+      lastTransactions: [
+        {
+          status: 1,
+          originalTransactionId: '1000000000000001',
+          signedTransactionInfo: signedTransaction('com.example.pro.monthly'),
+        },
+      ],
+    },
+    {
+      subscriptionGroupIdentifier: 'group-extra',
+      lastTransactions: [
+        {
+          status: 1,
+          originalTransactionId: '1000000000000002',
+          signedTransactionInfo: signedTransaction('com.example.extra.storage'),
+        },
+      ],
+    },
+  ],
+};
+
+const entitlement = (response: StatusResponse, args: Record<string, unknown>) =>
+  (new StoreKitService(config) as never as {
+    checkEntitlement(client: never, args: Record<string, unknown>): Promise<{
+      entitled: boolean;
+      activeCount: number;
+      subscriptions: unknown[];
+    }>;
+  }).checkEntitlement(stubClient(response), args);
+
+describe('check_entitlement', () => {
+  it('narrows to the requested product', async () => {
+    const res = await entitlement(twoProducts, {
+      transaction_id: '1000000000000001',
+      product_id: 'com.example.pro.monthly',
+    });
+
+    expect(res.entitled).toBe(true);
+    expect(res.activeCount).toBe(1);
+    expect(res.subscriptions).toHaveLength(1);
+  });
+
+  it('is not entitled to a product the customer does not hold', async () => {
+    const res = await entitlement(twoProducts, {
+      transaction_id: '1000000000000001',
+      product_id: 'com.example.premium.yearly',
+    });
+
+    expect(res.entitled).toBe(false);
+    expect(res.activeCount).toBe(0);
+    expect(res.subscriptions).toEqual([]);
+  });
+
+  it('counts every product when none is named', async () => {
+    const res = await entitlement(twoProducts, {
+      transaction_id: '1000000000000001',
+    });
+
+    expect(res.entitled).toBe(true);
+    expect(res.activeCount).toBe(2);
+  });
+
+  it('treats grace period as entitled and expiry as not', async () => {
+    const response: StatusResponse = {
+      data: [
+        {
+          subscriptionGroupIdentifier: 'group-pro',
+          lastTransactions: [
+            { status: 4, signedTransactionInfo: signedTransaction('a') },
+            { status: 2, signedTransactionInfo: signedTransaction('b') },
+          ],
+        },
+      ],
+    };
+
+    const res = await entitlement(response, { transaction_id: '1' });
+
+    expect(res.entitled).toBe(true);
+    expect(res.activeCount).toBe(1); // the expired one does not count
+  });
+
+  it('drops a transaction whose payload cannot be read rather than matching it', async () => {
+    const response: StatusResponse = {
+      data: [
+        {
+          subscriptionGroupIdentifier: 'group-pro',
+          lastTransactions: [
+            { status: 1, signedTransactionInfo: 'not.a.jws' },
+            { status: 1 }, // no payload at all
+          ],
+        },
+      ],
+    };
+
+    const res = await entitlement(response, {
+      transaction_id: '1',
+      product_id: 'com.example.pro.monthly',
+    });
+
+    expect(res.entitled).toBe(false);
+  });
+
+  it('reports nothing when the customer has no subscriptions', async () => {
+    const res = await entitlement({}, { transaction_id: '1' });
+
+    expect(res.entitled).toBe(false);
+    expect(res.activeCount).toBe(0);
+  });
+});


### PR DESCRIPTION
Two commits: a dependency bump, and a correctness bug found while removing the `any` casts that hid it.

## The bug

`storekit__check_entitlement` takes an optional `product_id`, documented as *"Only count this product as granting entitlement."* It did not do that. The filter was:

```ts
(t: any) => t.originalTransactionId && g.subscriptionGroupIdentifier
```

That mentions neither `product_id` nor anything derived from it, and is true for essentially every transaction. **A customer holding any active subscription was reported as entitled to every product, including ones they had never bought.**

A product ID is not on the subscription-group item — it lives inside each transaction's signed payload. Narrowing means opening that payload and keeping only the groups that still hold a transaction afterwards.

`jwsClaim` reads a claim without verifying the signature. That is sound here: the JWS arrived over TLS from an endpoint we authenticated to, and nothing in this path grants access. Callers needing a verified payload still have the library's `SignedDataVerifier`.

## Why it survived

`t: any` is why. With the parameter typed, the predicate reads as obviously vacuous; as `any` the whole block looked like library plumbing rather than logic anyone had to check.

The rest of the file drops `any` for the same reason:

| Was | Is |
| :--- | :--- |
| `const res: any` (×3) | `HistoryResponse`, `RefundHistoryResponse`, `StatusResponse` |
| `'v2' as any` | `GetTransactionHistoryVersion.V2` |
| `} as any` (request bodies, ×2) | `NotificationHistoryRequest`, `ExtendRenewalDateRequest` |
| `t.status === 1 \|\| t.status === 4` | `Status.ACTIVE`, `Status.BILLING_GRACE_PERIOD` |

Those casts are why PR #17 had to be verified by hand — typecheck could not see through them, so a changed signature would have compiled clean. `Record<string, any>` stays on the tool arguments, which really are untyped JSON.

## Tests

Six new tests in `tests/storekit.test.ts`. Verified they catch the bug by restoring the old filter and re-running — two fail:

```
× narrows to the requested product
× is not entitled to a product the customer does not hold
Tests  2 failed | 4 passed (6)
```

Full suite: 344 passing, typecheck and build clean.

## The dependency bump

`ip-address` 10.2.0 → 10.4.0, closing [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) — IPv4-mapped and NAT64 IPv6 addresses misclassified, slipping past SSRF checks.

It arrives via `@modelcontextprotocol/sdk → express-rate-limit`, which only loads behind the SDK's HTTP transport. This server speaks stdio and nothing else ([src/index.ts:128,158](src/index.ts#L128)), so the path is unreachable here — but it ships in the tree, and the range is `^10.2.0`.

`npm audit` reports zero for it: the advisory is new enough that OSV has it and the registry's audit endpoint does not. Scorecard reads OSV, which is how it surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)