### PR TITLE
fix: report unreadable payloads in check_entitlement; slim the npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "files": [
     "dist",
-    "spec/openapi.json",
     "README.md",
     "AGENTS.md",
     "docs/GUIDE.md",

--- a/src/storekit/index.ts
+++ b/src/storekit/index.ts
@@ -420,13 +420,19 @@ export class StoreKitService {
     // product ID lives inside each transaction's signed payload — so narrowing
     // to one product means reading that payload, and keeping only the groups
     // that still hold a transaction afterwards.
+    let undecodable = 0;
     const matching: SubscriptionGroupIdentifierItem[] = args.product_id
       ? groups
           .map((g) => ({
             ...g,
-            lastTransactions: (g.lastTransactions ?? []).filter(
-              (t) => jwsClaim(t.signedTransactionInfo, 'productId') === args.product_id
-            ),
+            lastTransactions: (g.lastTransactions ?? []).filter((t) => {
+              const productId = jwsClaim(t.signedTransactionInfo, 'productId');
+              // An unreadable payload is not a mismatch, it is an unknown. It
+              // still drops out — we will not grant on a guess — but saying so
+              // keeps "does not hold this product" apart from "could not tell".
+              if (productId === undefined) undecodable++;
+              return productId === args.product_id;
+            }),
           }))
           .filter((g) => g.lastTransactions.length > 0)
       : groups;
@@ -442,9 +448,14 @@ export class StoreKitService {
       activeCount: active.length,
       // Statuses are JWS-signed; the caller decodes them if they need detail.
       subscriptions: matching,
+      ...(undecodable > 0 ? { undecodableTransactions: undecodable } : {}),
       note:
         'Status 1 = Active, 4 = Grace period. Both are treated as entitled. ' +
-        'Signed payloads are returned verbatim for you to verify.',
+        'Signed payloads are returned verbatim for you to verify.' +
+        (undecodable > 0
+          ? ` ${undecodable} transaction(s) had an unreadable payload and were excluded, ` +
+            'so a negative result here means "could not confirm", not "does not hold".'
+          : ''),
     };
   }
 }

--- a/tests/storekit.test.ts
+++ b/tests/storekit.test.ts
@@ -67,7 +67,8 @@ const entitlement = (response: StatusResponse, args: Record<string, unknown>) =>
     checkEntitlement(client: never, args: Record<string, unknown>): Promise<{
       entitled: boolean;
       activeCount: number;
-      subscriptions: unknown[];
+      subscriptions: { subscriptionGroupIdentifier?: string }[];
+      undecodableTransactions?: number;
     }>;
   }).checkEntitlement(stubClient(response), args);
 
@@ -81,6 +82,8 @@ describe('check_entitlement', () => {
     expect(res.entitled).toBe(true);
     expect(res.activeCount).toBe(1);
     expect(res.subscriptions).toHaveLength(1);
+    // The one that survived must be the pro group, not merely "one of them".
+    expect(res.subscriptions[0].subscriptionGroupIdentifier).toBe('group-pro');
   });
 
   it('is not entitled to a product the customer does not hold', async () => {
@@ -141,6 +144,17 @@ describe('check_entitlement', () => {
     });
 
     expect(res.entitled).toBe(false);
+    // ...but says so, so the caller can tell this apart from a real "no".
+    expect(res.undecodableTransactions).toBe(2);
+  });
+
+  it('omits the undecodable count when every payload was readable', async () => {
+    const res = await entitlement(twoProducts, {
+      transaction_id: '1000000000000001',
+      product_id: 'com.example.pro.monthly',
+    });
+
+    expect(res.undecodableTransactions).toBeUndefined();
   });
 
   it('reports nothing when the customer has no subscriptions', async () => {


### PR DESCRIPTION
Two independent changes, one commit each.

## `check_entitlement` reports unreadable payloads

`43b9398` fixed the product-narrowing bug: a product ID is not on the subscription-group item, it lives inside each transaction's signed JWS payload, so narrowing means opening that payload.

That left a gap. When a payload cannot be decoded, the transaction drops out of the filter and the tool answers a flat `entitled: false` — identical to what a customer who genuinely does not hold the product gets back. "Could not tell" and "does not hold" are different answers, and the caller had no way to distinguish them.

This counts those transactions and returns `undecodableTransactions`, present only when non-zero so an ordinary answer is byte-for-byte unchanged. The `note` field explains what a negative result means when the count is there.

The filtering itself is untouched — an unreadable payload still drops out. `jwsClaim` keeps failing closed; nothing is granted on a guess.

Tests: the positive narrowing case now asserts it got `group-pro` back rather than merely "one group", and two tests pin the new field (present with the expected count when payloads are broken, absent when they are all readable).

## Stop shipping the OpenAPI spec

`spec/openapi.json` is 3.3 MB and sits in `package.json`'s `files` list, so every `npm install` pulls it down. Nothing reads it at runtime — the only consumers are `scripts/generate.ts` and `scripts/update-spec.ts`, and `scripts/` does not ship. Installers were downloading half the tarball for a file they had no generator to run against.

It stays in the repo, where the README's reproducibility claim actually holds because the generator is there too.

Tarball: 6.7 MB → 3.3 MB unpacked, 426 kB → 272 kB on the wire.

## Verification

`npm run build`, `npm run typecheck`, and `npm test` all pass — 345 passed, 1 expected fail, 3 skipped across 25 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)