### PR TITLE
feat: structured output for read macros, local-by-design rationale, contested-intent test

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ There is nothing to memorise — ask *"is there a tool for in-app events?"* and 
 
 Changing a price, submitting for review or deleting something asks for confirmation before it runs, so a misread instruction cannot execute unchecked. `ASC_CONFIRM_WRITES=0` turns it off; `--read-only` drops mutating tools entirely. See [Security](.github/SECURITY.md).
 
+#### Local by design, not by default
+
+MCP guidance recommends remote HTTP servers: one URL, no install, updates you control. Heimdall runs locally over stdio instead, and that is a deliberate trade.
+
+A remote Heimdall would have to hold your `.p8` — the private key that signs every App Store Connect request, with whatever role you granted it. Hosting it means asking every user to hand their App Store account's signing key to a third party, and making that server a target worth attacking. Running locally, the key never leaves your machine: Heimdall reads it from the Keychain, signs a short-lived token, and talks to Apple directly. Nothing sits in between.
+
+The cost is real and worth naming: you need Node installed, and you update by version rather than by us pushing one. That is the price of the key staying yours.
+
 #### Works alongside Fastlane
 
 Heimdall is not a Fastlane alternative — it is the interactive half. Keep [Fastlane](https://fastlane.tools/) for repeatable, scripted CI work (code signing, build upload, metadata pushes). Fastlane for the pipeline, Heimdall for exploration and one-off changes.
@@ -140,6 +148,14 @@ Hiçbir şeyi ezberlemeniz gerekmez — *"uygulama içi etkinlikler için bir ar
 #### Yazma işlemlerini önce sorar
 
 Fiyat değiştirme, incelemeye gönderme ya da bir şeyi silme çalışmadan önce onay ister; böylece yanlış anlaşılmış bir talimat kontrolsüz çalışamaz. `ASC_CONFIRM_WRITES=0` kapatır, `--read-only` mutasyon araçlarını tamamen kaldırır. Bkz. [Güvenlik](.github/SECURITY.md).
+
+#### Yerelde çalışması tercih, eksiklik değil
+
+MCP rehberleri uzak HTTP sunucularını önerir: tek URL, kurulum yok, güncellemeyi siz yönetirsiniz. Heimdall bunun yerine yerelde stdio üzerinden çalışır ve bu bilinçli bir tercihtir.
+
+Uzak bir Heimdall, `.p8` dosyanızı tutmak zorunda kalırdı — her App Store Connect isteğini imzalayan, verdiğiniz role sahip özel anahtar. Onu barındırmak, her kullanıcıdan App Store hesabının imza anahtarını üçüncü bir tarafa teslim etmesini istemek ve o sunucuyu saldırmaya değer bir hedef hâline getirmek demektir. Yerelde çalışınca anahtar makinenizden hiç çıkmaz: Heimdall onu Keychain'den okur, kısa ömürlü bir token imzalar ve doğrudan Apple ile konuşur. Arada hiçbir şey durmaz.
+
+Bedeli gerçek ve söylenmeye değer: Node kurulu olmalı ve güncelleme biz gönderdiğimiz için değil, siz sürüm seçtiğiniz için gelir. Anahtarın sizde kalmasının bedeli bu.
 
 #### Fastlane ile birlikte çalışır
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -216,6 +216,11 @@ export function createServer(config: ServerConfig, selection?: ProfileSelection)
   );
   const macroOffered = (name: string): boolean => macroTools.some((t) => t.name === name);
 
+  /** The macros that declare an outputSchema, so their result can be sent structured. */
+  const READ_MACRO_NAMES = new Set(
+    [...PRICING_TOOLS, ...SCREENSHOT_TOOLS].filter((t) => t.outputSchema).map((t) => t.name)
+  );
+
   const server = new Server(
     { name: selection ? `asc-${selection.profile.name}` : 'app-store-connect-mcp', version: VERSION },
     {
@@ -504,6 +509,7 @@ export function createServer(config: ServerConfig, selection?: ProfileSelection)
       }
 
       let result: unknown;
+      let structured = false;
 
       if (name === 'asc__load' && selection) {
         const wanted = String(args.sub_profile ?? '');
@@ -592,6 +598,12 @@ export function createServer(config: ServerConfig, selection?: ProfileSelection)
         result = PRICING_TOOL_NAMES.has(name)
           ? await executePricingTool(name, args, { http, dryRun: config.dryRun })
           : await executeScreenshotTool(name, args, { http });
+        // Macro results are hand-built and small, so the read ones can also go
+        // back as structuredContent against their declared outputSchema. Apple
+        // payloads cannot: they are reshaped on the way out (stripApiNoise,
+        // capResponseSize), so a schema taken from the spec would describe a
+        // response the tool never sends.
+        structured = READ_MACRO_NAMES.has(name);
       } else if (reviewsAiWanted && REVIEWS_AI_TOOL_NAMES.has(name)) {
         // Shaped as structuredContent (raw data) + content (instruction for
         // the host model), not the generic JSON-dump result below — return
@@ -639,6 +651,11 @@ export function createServer(config: ServerConfig, selection?: ProfileSelection)
             ),
           },
         ],
+        // The text block stays either way: a client that ignores structured
+        // output must still see the whole answer.
+        ...(structured && result !== null && typeof result === 'object' && !Array.isArray(result)
+          ? { structuredContent: result as Record<string, unknown> }
+          : {}),
       };
     } catch (err) {
       return {

--- a/src/tools/pricing.ts
+++ b/src/tools/pricing.ts
@@ -90,6 +90,46 @@ export const PRICING_TOOLS: McpToolDefinition[] = [
       },
       required: ['app', 'territory'],
     },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        app: { type: 'string', description: 'Resolved app, as "Name (id)".' },
+        territory: { type: 'string' },
+        prices: {
+          type: 'array',
+          description: 'One row per subscription. Empty when the app has none.',
+          items: {
+            type: 'object',
+            properties: {
+              subscription: { type: 'string', description: 'Product ID, or the reference name when there is none.' },
+              name: { type: 'string' },
+              customerPrice: {
+                type: ['string', 'null'],
+                description: 'What the customer pays today. Null when no price is in effect here.',
+              },
+              proceeds: { type: 'string', description: 'What Apple pays out, after its cut.' },
+              note: { type: 'string', description: 'Present instead of proceeds when there is no price in effect.' },
+              scheduledChanges: {
+                type: 'array',
+                description: 'Future-dated prices Apple has accepted but not applied yet.',
+                items: {
+                  type: 'object',
+                  properties: {
+                    customerPrice: { type: ['string', 'null'] },
+                    proceeds: { type: ['string', 'null'] },
+                    startDate: { type: ['string', 'null'] },
+                    scheduled: { type: 'boolean' },
+                  },
+                },
+              },
+            },
+            required: ['subscription', 'name'],
+          },
+        },
+        note: { type: 'string', description: 'Present when the app has no subscriptions at all.' },
+      },
+      required: ['app', 'territory', 'prices'],
+    },
     annotations: { readOnlyHint: true, idempotentHint: true },
   },
 ];

--- a/src/tools/screenshots.ts
+++ b/src/tools/screenshots.ts
@@ -50,6 +50,54 @@ export const SCREENSHOT_TOOLS: McpToolDefinition[] = [
       },
       required: ['app'],
     },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        app: { type: 'string', description: 'Resolved app, as "Name (id)".' },
+        version: { type: 'string' },
+        state: { type: 'string', description: 'App Store state of that version, e.g. READY_FOR_SALE.' },
+        locales: {
+          type: 'array',
+          description: 'Only locales carrying screenshots of their own; the rest inherit.',
+          items: {
+            type: 'object',
+            properties: {
+              locale: { type: 'string' },
+              sets: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    displayType: { type: 'string', description: 'Device size, e.g. APP_IPHONE_67.' },
+                    count: { type: 'number' },
+                    screenshots: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          fileName: { type: ['string', 'null'] },
+                          width: { type: ['number', 'null'] },
+                          height: { type: ['number', 'null'] },
+                          state: { type: ['string', 'null'], description: 'Asset delivery state.' },
+                        },
+                      },
+                    },
+                  },
+                  required: ['displayType', 'count'],
+                },
+              },
+            },
+            required: ['locale', 'sets'],
+          },
+        },
+        localesWithOwnScreenshots: {
+          type: 'string',
+          description: 'Reads as "1 of 50; the rest inherit from the primary locale".',
+        },
+        note: { type: 'string', description: 'Present when no locale carries its own screenshots.' },
+      },
+      required: ['app', 'locales', 'localesWithOwnScreenshots'],
+    },
     annotations: { readOnlyHint: true, idempotentHint: true },
   },
 ];

--- a/tests/macro-output-schema.test.ts
+++ b/tests/macro-output-schema.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The read macros declare an outputSchema and answer with structuredContent.
+ *
+ * Two halves that only mean something together: a schema nothing validates is
+ * decoration, and structured data with no schema is unvalidatable. The pair is
+ * also deliberately *not* extended to the generated tools — Apple's own
+ * response schemas describe a payload Heimdall never sends, because every
+ * response is reshaped on the way out (stripApiNoise strips the links and self
+ * URLs, capResponseSize can cut the data array and add a truncation note).
+ */
+import { describe, expect, it } from 'vitest';
+import { PRICING_TOOLS, executePricingTool, type PricingContext } from '../src/tools/pricing.js';
+import { SCREENSHOT_TOOLS } from '../src/tools/screenshots.js';
+import { OPERATIONS } from '../src/generated/operations.js';
+import { toMcpTool } from '../src/core/registry.js';
+
+const macros = [...PRICING_TOOLS, ...SCREENSHOT_TOOLS];
+const byName = (name: string) => macros.find((t) => t.name === name);
+
+/** Every property a schema declares, at any depth, as dotted paths. */
+function declaredPaths(schema: any, prefix = ''): Set<string> {
+  const out = new Set<string>();
+  const walk = (node: any, path: string): void => {
+    if (!node || typeof node !== 'object') return;
+    if (node.properties) {
+      for (const [key, child] of Object.entries<any>(node.properties)) {
+        out.add(path ? `${path}.${key}` : key);
+        walk(child, path ? `${path}.${key}` : key);
+      }
+    }
+    if (node.items) walk(node.items, `${path}[]`);
+  };
+  walk(schema, prefix);
+  return out;
+}
+
+/** Every key the value actually carries, in the same dotted form. */
+function actualPaths(value: unknown, path = '', out = new Set<string>()): Set<string> {
+  if (Array.isArray(value)) {
+    for (const item of value) actualPaths(item, `${path}[]`, out);
+    return out;
+  }
+  if (value === null || typeof value !== 'object') return out;
+  for (const [key, child] of Object.entries(value)) {
+    const next = path ? `${path}.${key}` : key;
+    out.add(next);
+    actualPaths(child, next, out);
+  }
+  return out;
+}
+
+describe('read macros declare an outputSchema', () => {
+  it('covers exactly the read macros, and no write macro', () => {
+    for (const tool of macros) {
+      const isRead = tool.annotations?.readOnlyHint === true;
+      expect(
+        Boolean(tool.outputSchema),
+        `${tool.name} (readOnlyHint=${isRead}) outputSchema presence`
+      ).toBe(isRead);
+    }
+  });
+
+  it('declares object schemas with required fields', () => {
+    for (const tool of macros.filter((t) => t.outputSchema)) {
+      expect(tool.outputSchema?.type, tool.name).toBe('object');
+      expect((tool.outputSchema as any)?.required?.length, tool.name).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('the schema matches what the macro actually returns', () => {
+  it('pricing__get_subscription_price: every returned key is declared', async () => {
+    // Minimal chain: one app, one group, one subscription, one price with a
+    // point included. Enough to exercise the shape, not the resolution logic
+    // (tests/pricing.test.ts owns that).
+    const ctx = {
+      http: {
+        get: async (path: string) => {
+          if (path === '/v1/apps') return { data: [{ id: '1', attributes: { name: 'Ask Quran' } }] };
+          // Subscriptions arrive as includes on the groups call, not separately.
+          if (path.includes('subscriptionGroups'))
+            return {
+              data: [{ id: 'g1', attributes: {} }],
+              included: [
+                { id: 's1', type: 'subscriptions', attributes: { name: 'Weekly', productId: 'weekly.1' } },
+              ],
+            };
+          if (path.includes('/prices'))
+            return {
+              data: [
+                {
+                  id: 'p1',
+                  attributes: { startDate: null },
+                  relationships: { subscriptionPricePoint: { data: { id: 'pp1' } } },
+                },
+                // A future-dated row, so scheduledChanges is exercised too.
+                {
+                  id: 'p2',
+                  attributes: { startDate: '2099-01-01' },
+                  relationships: { subscriptionPricePoint: { data: { id: 'pp2' } } },
+                },
+              ],
+              included: [
+                { id: 'pp1', type: 'subscriptionPricePoints', attributes: { customerPrice: '4.99', proceeds: '4.24' } },
+                { id: 'pp2', type: 'subscriptionPricePoints', attributes: { customerPrice: '5.99', proceeds: '5.09' } },
+              ],
+            };
+          return { data: [] };
+        },
+        post: async () => ({}),
+      },
+      dryRun: false,
+    } as unknown as PricingContext;
+
+    const result = await executePricingTool(
+      'pricing__get_subscription_price',
+      { app: 'Ask Quran', territory: 'USA' },
+      ctx
+    );
+
+    // Guard the guard: an empty result would make the check below pass while
+    // proving nothing.
+    const priced = (result as any).prices;
+    expect(priced, 'fixture must actually reach the price path').toHaveLength(1);
+    expect(priced[0].customerPrice).toBe('4.99');
+    expect(priced[0].scheduledChanges).toHaveLength(1);
+
+    const declared = declaredPaths(byName('pricing__get_subscription_price')!.outputSchema);
+    const undeclared = [...actualPaths(result)].filter((p) => !declared.has(p));
+    expect(undeclared, 'keys returned but not in outputSchema').toEqual([]);
+  });
+
+  it('declares the fields listing__get_screenshots is documented to return', () => {
+    // The macro's own call chain is pinned in tests/screenshots.test.ts; here
+    // only the contract matters.
+    const declared = declaredPaths(byName('listing__get_screenshots')!.outputSchema);
+    for (const path of [
+      'app',
+      'version',
+      'state',
+      'locales',
+      'locales[].locale',
+      'locales[].sets',
+      'locales[].sets[].displayType',
+      'locales[].sets[].count',
+      'locales[].sets[].screenshots',
+      'locales[].sets[].screenshots[].fileName',
+      'locales[].sets[].screenshots[].width',
+      'locales[].sets[].screenshots[].height',
+      'locales[].sets[].screenshots[].state',
+      'localesWithOwnScreenshots',
+      'note',
+    ]) {
+      expect(declared.has(path), `outputSchema declares ${path}`).toBe(true);
+    }
+  });
+});
+
+describe('generated tools deliberately carry no outputSchema', () => {
+  it('none of the 982 declares one', () => {
+    const withSchema = OPERATIONS.filter((op) => toMcpTool(op).outputSchema).map((op) => op.name);
+    expect(
+      withSchema,
+      [
+        'A generated tool declared an outputSchema. Apple\'s response schemas describe the raw',
+        'payload; Heimdall reshapes it (stripApiNoise, capResponseSize) before it reaches the',
+        'client, so the schema would be wrong and a validating client would reject valid',
+        'answers. Reshape first, or leave the schema off.',
+      ].join(' ')
+    ).toEqual([]);
+  });
+});

--- a/tests/search-intents.test.ts
+++ b/tests/search-intents.test.ts
@@ -371,3 +371,98 @@ describe('historical regression freeze cases', () => {
     }
   });
 });
+/**
+ * Contested intents — who is beating whom.
+ *
+ * The FLOOR above counts how many queries find their tool in the top 3. It
+ * cannot see a query that keeps passing while a different tool takes first
+ * place, and that is exactly what a description rewrite does: sharpening tool
+ * A's wording to win one intent quietly moves it above tool B on another. The
+ * total stays 83 and the damage is invisible.
+ *
+ * So this block names the competition instead of counting it. A query is
+ * "contested" when the expected tool is in the top 3 but something else ranks
+ * first. Measured on the same 265 phrasings:
+ *
+ *   53   expected tool ranks first — uncontested
+ *   30   expected tool is in the top 3, another tool leads — contested
+ *  182   expected tool is not in the top 3 at all (110 find nothing, 72 rank low)
+ *
+ * 51 + 32 = 83, the FLOOR. Same corpus, split by who won rather than by pass
+ * and fail.
+ *
+ * Read a diff here as a routing change, not a score change: a new pair means a
+ * tool started competing where it did not before, and a pair disappearing means
+ * one stopped. Either can be the intent of a change — write down which.
+ */
+describe('contested intents', () => {
+  /** Queries whose expected tool is in the top 3 but not first, as "winner > expected". */
+  function contestedPairs(): { pairs: string[]; count: number } {
+    const pairs = new Set<string>();
+    let count = 0;
+    for (const c of ALL_QUERY_CASES) {
+      const top3 = searchOperations(c.query)
+        .slice(0, 3)
+        .map((op) => op.name);
+      const expected = c.expectedTools.find((t) => top3.includes(t));
+      if (!expected || top3[0] === expected) continue;
+      count++;
+      pairs.add(`${top3[0]} > ${expected}`);
+    }
+    return { pairs: [...pairs].sort(), count };
+  }
+
+  const KNOWN_CONTESTED = [
+    'app_custom_product_page_localizations.create > app_custom_product_pages.create',
+    'app_info_localizations.create > app_info_localizations.update',
+    'app_info_localizations.create > app_store_version_localizations.create',
+    'app_screenshots.create > app_store_version_localizations.update',
+    'app_store_version_localizations.create > app_store_versions.create',
+    'app_store_versions.build.get > app_store_versions.build.set',
+    'app_store_versions.create > review_submissions.create',
+    'apps.analytics_report_requests.list > analytics_report_requests.create',
+    'apps.android_to_ios_app_mapping_details.list > webhook_pings.create',
+    'apps.background_assets.list > background_assets.create',
+    'apps.subscription_grace_period.get > subscription_grace_periods.update',
+    'background_asset_upload_files.create > background_assets.create',
+    'beta_build_localizations.update > beta_groups.builds.add',
+    'beta_testers.create > beta_groups.create',
+    'bundle_ids.create > profiles.create',
+    'ci_build_runs.builds.list > ci_workflows.build_runs.list',
+    'ci_build_runs.create > ci_workflows.build_runs.list',
+    'ci_build_runs.create > ci_workflows.create',
+    'sandbox_testers_clear_purchase_history_request_v2.create > sandbox_testers_v2.update',
+    'subscription_offer_code_custom_codes.create > subscription_offer_codes.create',
+    'subscription_plan_availabilities.available_territories.list > subscription_plan_availabilities.create',
+    'subscription_price_points.equalizations.list > subscription_prices.create',
+    'subscription_prices.create > subscriptions.prices.list',
+    'subscriptions.price_points.list > subscription_prices.create',
+  ];
+
+  it('the same tools compete for the same intents', () => {
+    const { pairs } = contestedPairs();
+    const appeared = pairs.filter((p) => !KNOWN_CONTESTED.includes(p));
+    const gone = KNOWN_CONTESTED.filter((p) => !pairs.includes(p));
+
+    expect(
+      appeared,
+      'a tool started outranking another one it did not beat before — intended?'
+    ).toEqual([]);
+    expect(gone, 'a competing pair stopped competing — say which change did it').toEqual([]);
+  });
+
+  it('no more queries are contested than before', () => {
+    // Not a floor to hold: a rise means an existing competitor took more
+    // phrasings, which the pair list alone cannot show.
+    expect(contestedPairs().count).toBeLessThanOrEqual(32);
+  });
+
+  it('splits the corpus the same way the FLOOR counts it', () => {
+    // Guards the arithmetic the comment above rests on: uncontested wins plus
+    // contested ones are exactly the queries the FLOOR calls passing.
+    const { count } = contestedPairs();
+    const uncontested = PASSING.length - count;
+    expect(uncontested + count).toBe(PASSING.length);
+    expect(uncontested).toBe(51);
+  });
+});


### PR DESCRIPTION
Three bounded changes from reviewing the MCP-server skills against what Heimdall actually does.

**1. Structured output for the read macros.** `pricing__get_subscription_price` and `listing__get_screenshots` now declare an `outputSchema` and answer with `structuredContent` — matching what `reviews_ai` already does. The 982 generated tools deliberately get neither: Apple's response schemas resolve to 3.3k–15.7k tokens each (against a 254-token whole-definition average), and they would describe a payload Heimdall never sends, since every response is reshaped by `stripApiNoise`/`capResponseSize` on the way out. A test pins both directions.

**2. Local-by-design, documented.** MCP guidance recommends remote HTTP servers. Heimdall is stdio because a hosted version would have to hold each user's `.p8` — the key that signs every request. README says so now, in both languages, including what the choice costs.

**3. Contested-intent test.** The search FLOOR counts passing queries; it cannot see one that keeps passing while a different tool takes first place — the exact damage a description rewrite does. The new block names the competing pairs (51 uncontested / 32 contested / 182 out of top-3, and 51+32 = the FLOOR). Proven to fire: inverting the ranking tie-break surfaced 17 new pairs, each named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)