### PR TITLE
test: prove a regex metacharacter in a short token cannot throw

### DIFF
--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -164,4 +164,21 @@ describe('short tokens do not match mid-word', () => {
       expect(searchOperations(q).length, q).toBeGreaterThan(0);
     }
   });
+
+  it('survives a short token that is a regex metacharacter', () => {
+    // A token under three characters is compiled into a RegExp, so anything the
+    // query tokenizer does not strip reaches the constructor. It splits on
+    // whitespace and , . : ; ! ? " ' ’ ( ) [ ] — everything else survives, and
+    // an unescaped `*` or `{` there is a thrown SyntaxError on a user's search,
+    // not a ranking mistake. Cheap to assert, expensive to find in production.
+    const hostile = [
+      '*', '+', '?', '^', '$', '{', '}', '|', '\\', '/', '-', '<', '>', '&', '#', '=', '~', '@',
+      'a*', '*b', '{}', '|-', '$^', '(?', 'a\\', '--', '**', '??', '\\\\', '[]',
+    ];
+    for (const token of hostile) {
+      expect(() => searchOperations(token), JSON.stringify(token)).not.toThrow();
+      // Also alongside real words, where the token has to survive scoring too.
+      expect(() => searchOperations(`price ${token} app`), JSON.stringify(token)).not.toThrow();
+    }
+  });
 });


### PR DESCRIPTION
Closes the one follow-up from the pre-release review of `6fb640a`.

A token under three characters is compiled into a `RegExp`, so whatever `tokenize` does not strip reaches the constructor. It splits on whitespace and `, . : ; ! ? " ' ' ( ) [ ]` and leaves everything else — `*`, `{`, `\` and friends can arrive as a whole token. Unescaped, that is a `SyntaxError` thrown on someone's search, not a ranking mistake.

`escapeRegExp` already covers them, so this fixes nothing. The point is that the guarantee was *argued* — walk the split set, walk the escape set, observe they cover — and an argument does not fail CI when someone edits the escape set later.

Replacing `escapeRegExp` with the identity function turns this test red. That is the property the two tests next to it lack: `ci` and the ordinary-query cases pass even with the short-token rule reverted, so they protect behaviour without evidencing the change. Worth being explicit about which is which.

30 hostile tokens, each tried alone and inside a real query so it has to survive scoring too.

`npm test` — 427 passed, 1 expected fail, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)