### PR TITLE
docs: catch the published metadata up to what 2.0.0 actually ships

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "Heimdall"
-abstract: "An MCP server for the Apple App Store Connect API and App Store Server API (StoreKit 2), with 982 tools generated from Apple's official OpenAPI spec, AI-powered review triage, and confirm-before-write safety."
+abstract: "An MCP server for the Apple App Store Connect API and App Store Server API (StoreKit 2), with 868 tools generated from Apple's official OpenAPI spec, 13 curated profiles that keep each session small, and confirm-before-write safety."
 type: software
 authors:
   - family-names: "Endes"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,8 @@ authors:
 repository-code: "https://github.com/erayendes/app-store-connect-mcp"
 url: "https://github.com/erayendes/app-store-connect-mcp"
 license: MIT
-version: 1.3.0
-date-released: "2026-07-28"
+version: 2.0.0
+date-released: "2026-08-05"
 keywords:
   - mcp
   - model-context-protocol

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **Heimdall.** One tool for your entire App Store Connect account.
 
-An MCP server for the **App Store Connect API** and the **App Store Server API (StoreKit 2)**, with every tool generated from Apple's own OpenAPI specification. **13 profiles, 40 sub-profiles, 868 tools.**
+An MCP server for the **App Store Connect API** and the **App Store Server API (StoreKit 2)**, with every tool generated from Apple's own OpenAPI specification. **13 profiles, 32 sub-profiles, 868 tools.**
 
 Apps and metadata, versions and phased releases, TestFlight, subscriptions and in-app purchases, pricing, reviews, Game Center, Xcode Cloud, provisioning, webhooks, and sales and finance reports.
 
@@ -46,7 +46,7 @@ Most App Store Connect MCP servers offer a hand-picked slice of the API. That wo
 
 | | |
 | :--- | :--- |
-| **Complete** | Apple's OpenAPI spec v4.4.1, all 966 paths, 982 operations. `npm run spec:update` brings Apple's changes in as a reviewable diff. |
+| **Complete** | Apple's OpenAPI spec v4.4.1, all 966 paths, 982 operations — 281 id-only duplicates already collapsed, and the 123 Apple has deprecated stay unloaded unless you ask for them, which leaves the 859 reachable operations plus nine hand-written tools. `npm run spec:update` brings Apple's changes in as a reviewable diff. |
 | **Narrowable** | 13 purpose-built profiles, each narrowing further — `monetization:subscription-pricing` is 24 tools instead of 204. The whole surface would cost over 100k tokens of tool definitions; one profile costs a fraction of that. |
 | **StoreKit 2** | The App Store Server API too — customer transactions, entitlements, refunds. **Rare among ASC MCP servers.** |
 | **No second API key** | Review triage, daily briefings and draft replies return the review data — your own model writes the text. |
@@ -107,7 +107,7 @@ Tool definitions in `src/generated/` are produced from Apple Inc.'s published Ap
 
 **Heimdall.** Tüm App Store Connect hesabınız için tek bir araç.
 
-**App Store Connect API** ve **App Store Server API (StoreKit 2)** için bir MCP sunucusu; her aracı Apple'ın kendi OpenAPI spesifikasyonundan üretiliyor. **13 profil, 40 alt profil, 868 araç.**
+**App Store Connect API** ve **App Store Server API (StoreKit 2)** için bir MCP sunucusu; her aracı Apple'ın kendi OpenAPI spesifikasyonundan üretiliyor. **13 profil, 32 alt profil, 868 araç.**
 
 Uygulamalar ve metadata, sürümler ve kademeli yayınlar, TestFlight, abonelikler ve uygulama içi satın almalar, fiyatlandırma, yorumlar, Game Center, Xcode Cloud, provisioning, webhook'lar, satış ve finans raporları.
 
@@ -138,7 +138,7 @@ Setup sihirbazı API anahtarınızı bir kez ister, güvenle saklar ve seçtiği
 
 | | |
 | :--- | :--- |
-| **Eksiksiz** | Apple'ın OpenAPI spec v4.4.1'i, tüm 966 path, 982 işlem. `npm run spec:update` Apple'ın değişikliklerini gözden geçirilebilir bir diff olarak getirir. |
+| **Eksiksiz** | Apple'ın OpenAPI spec v4.4.1'i, tüm 966 path, 982 işlem — 281 id-only tekrar zaten birleştirilmiş durumda, Apple'ın kullanımdan kaldırdığı 123 işlem de siz istemedikçe yüklenmiyor; geriye erişilebilir 859 işlem artı elle yazılmış dokuz araç kalıyor. `npm run spec:update` Apple'ın değişikliklerini gözden geçirilebilir bir diff olarak getirir. |
 | **Daraltılabilir** | 13 amaca özel profil, her biri daha da daralabilir — `monetization:subscription-pricing` 204 yerine 24 araç. Tüm yüzey araç tanımları için 100 bin token'ı aşar; bir profil bunun küçük bir kısmı. |
 | **StoreKit 2** | App Store Server API de var — tüm müşteri işlemleri, haklar, iadeler. **ASC MCP sunucuları arasında nadir bir özellik.** |
 | **İkinci API anahtarı yok** | Yorum tasnifi, günlük brifing ve cevap taslakları yorum verisini döndürür — metni kendi modeliniz yazar. |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **Heimdall.** One tool for your entire App Store Connect account.
 
-An MCP server for the **App Store Connect API** and the **App Store Server API (StoreKit 2)**, with every tool generated from Apple's own OpenAPI specification. **13 profiles, 32 sub-profiles, 875 tools.**
+An MCP server for the **App Store Connect API** and the **App Store Server API (StoreKit 2)**, with every tool generated from Apple's own OpenAPI specification. **13 profiles, 40 sub-profiles, 868 tools.**
 
 Apps and metadata, versions and phased releases, TestFlight, subscriptions and in-app purchases, pricing, reviews, Game Center, Xcode Cloud, provisioning, webhooks, and sales and finance reports.
 
@@ -107,7 +107,7 @@ Tool definitions in `src/generated/` are produced from Apple Inc.'s published Ap
 
 **Heimdall.** Tüm App Store Connect hesabınız için tek bir araç.
 
-**App Store Connect API** ve **App Store Server API (StoreKit 2)** için bir MCP sunucusu; her aracı Apple'ın kendi OpenAPI spesifikasyonundan üretiliyor. **13 profil, 32 alt profil, 875 araç.**
+**App Store Connect API** ve **App Store Server API (StoreKit 2)** için bir MCP sunucusu; her aracı Apple'ın kendi OpenAPI spesifikasyonundan üretiliyor. **13 profil, 40 alt profil, 868 araç.**
 
 Uygulamalar ve metadata, sürümler ve kademeli yayınlar, TestFlight, abonelikler ve uygulama içi satın almalar, fiyatlandırma, yorumlar, Game Center, Xcode Cloud, provisioning, webhook'lar, satış ve finans raporları.
 

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.erayendes/asc-mcp",
-  "description": "App Store Connect + StoreKit 2 from any AI client. 982 tools, AI review triage, safe writes.",
+  "description": "App Store Connect + StoreKit 2 from any AI client. 868 tools across 13 curated profiles, safe writes.",
   "repository": {
     "url": "https://github.com/erayendes/app-store-connect-mcp",
     "source": "github"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/erayendes/app-store-connect-mcp",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "2.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@erayendes/asc-mcp",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Two things that never caught up after 2.0.0 went to npm on 5 August.

**Versions.** `server.json` still declared 1.2.0, so the MCP Registry has been advertising a version two releases behind the package it points at. `CITATION.cff` still declared 1.3.0 with that release's date. The `date-released` here is the 2.0.0 heading from `docs/CHANGELOG.md`, not today — a citation names when the software was released, not when its metadata was fixed.

**Counts.** Every user-facing tool count was wrong, in three different ways:

| Where | Was | Is |
|---|---|---|
| `server.json`, `CITATION.cff` | 982 tools | 868 |
| `README.md` (en + tr) | 875 tools, 32 sub-profiles | 868, 40 |

`982` counted operations generated from the spec, but 123 of those are deprecated and no profile loads them — the number promised a surface that cannot be reached. Measured against a booted server, `--domains=all` lists **868**: the 859 loadable operations plus three meta tools, three reviews helpers, and three workflow macros. It becomes 877 once `ASC_BUNDLE_ID` is set and the nine StoreKit tools load; 868 is the number that is true without configuration.

The README's 875/32 was a snapshot that drifted — `profiles.csv` now yields 40 sub-profiles.

Also dropped **"AI review triage"** from both descriptions. The `reviews_ai__*` tools still exist, but since 2.0.0 they return data and instructions and the host model writes the text; the server no longer does the triage itself.

**How the numbers were obtained:** `tools/list` over stdio on a running server with a throwaway key, not by summing `profiles.csv`. The two disagree, and only one of them is what a user sees. This is the failure mode MIL-214 tracks.

`npm test` 434 passing, `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)