### PR TITLE
ci: publish to the MCP Registry on release, and refuse to publish three different versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,27 @@ jobs:
           }
           console.log(`npm ${v} supports trusted publishing.`);'
 
+      # server.json is the only version this repo carries that nothing else
+      # reads, so it is the one that silently rots — it sat at 1.2.0 through
+      # two releases. npm would not have noticed: it reads package.json. Fail
+      # here instead, before anything is published anywhere.
+      - name: Fail if the three versions disagree
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          node -e 'const pkg = require("./package.json").version;
+          const srv = require("./server.json");
+          const tag = process.env.TAG.startsWith("v") ? process.env.TAG.slice(1) : null;
+          const seen = { "package.json": pkg, "server.json": srv.version, "server.json packages[0]": srv.packages[0].version };
+          if (tag) seen["git tag"] = tag;
+          const values = [...new Set(Object.values(seen))];
+          if (values.length > 1) {
+            console.error("Version mismatch:");
+            for (const [where, v] of Object.entries(seen)) console.error(`  ${where}: ${v}`);
+            process.exit(1);
+          }
+          console.log(`All versions agree on ${values[0]}.`);'
+
       - run: npm ci
 
       # Rebuild from the spec and fail if the committed output drifted, so a
@@ -55,6 +76,27 @@ jobs:
       # --provenance publishes a signed attestation linking the tarball to this
       # repository, commit and workflow run.
       - run: npm publish --provenance
+
+      # The MCP Registry is a separate publication from npm, and until now it
+      # had no step at all: 1.1.2 and 1.2.0 were pushed by hand and 1.3.0 and
+      # 2.0.0 were never pushed, so the registry advertised 1.2.0 while npm
+      # served 2.0.0. It reads server.json, which the check above has already
+      # matched against package.json and the tag.
+      #
+      # Deliberately not pinned. The publisher and the registry negotiate an
+      # OIDC audience, and an old binary fails with "invalid audience" — the
+      # documented fix is to fetch latest, so pinning buys a reproducible
+      # build at the price of a release that cannot publish.
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      # Same id-token: write this job already mints for npm, different
+      # audience. No secret, nothing to rotate.
+      - name: Publish to the MCP Registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
 
   # Separate job so the npm publish above keeps a read-only token: only this
   # step needs contents:write, and it never touches the OIDC path.


### PR DESCRIPTION
Follow-up to #39. That PR corrected `server.json` to 2.0.0 — and nothing would ever have read it.

**The registry has never been part of a release.** `publish.yml` only publishes to npm; there is no registry step and `mcp-publisher` does not appear anywhere in the repo. Checking the live registry now:

```
io.github.erayendes/asc-mcp   1.2.0   isLatest: true   published 2026-07-27
description: "...982 tools, AI review triage, safe writes."
```

1.1.2 and 1.2.0 were pushed by hand; 1.3.0 and 2.0.0 never were. So the registry advertises a version two releases behind npm, with a description promising review triage the server stopped doing in 2.0.0.

### What this adds

**A registry publish step.** Fetch `mcp-publisher`, then `login github-oidc` and `publish`. No secret: the job already mints an `id-token` for npm's trusted publishing and the registry accepts the same token with a different audience, so there is nothing new to store or rotate.

The binary is deliberately **not pinned**, against this repo's habit of pinning actions by SHA. The publisher and the registry negotiate an OIDC audience and an old binary fails with `invalid audience`; the documented fix is to fetch latest. Pinning would buy a reproducible install at the price of a release that cannot publish.

**A version guard**, because the publish step alone would not have prevented this. `server.json` is the only version in the repo that nothing reads back — npm reads `package.json`, the release notes read the tag — so it is the one that rots unnoticed. The check compares `package.json`, `server.json`, `server.json` `packages[0]` and, on a tag push, the tag itself, and runs before `npm ci` so a mismatch costs seconds instead of a half-published release.

### Verified

Ran the check against the current tree:

| Input | Result |
|---|---|
| `TAG=v2.0.0` | `All versions agree on 2.0.0.` exit 0 |
| `TAG=v2.1.0` | exit 1, printing all four sources and their values |
| `TAG=main` (workflow_dispatch) | exit 0, tag comparison skipped |

Nothing publishes on merge — both steps are inside the `v*`-tagged job, so the first real run is whenever 2.0.1 or 2.1.0 is tagged. Getting **2.0.0 itself** onto the registry still needs a manual `mcp-publisher publish`, which is yours to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)