### PR TITLE
fix: keep server.json's description under the registry's 100-character cap

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,10 @@ jobs:
       # reads, so it is the one that silently rots — it sat at 1.2.0 through
       # two releases. npm would not have noticed: it reads package.json. Fail
       # here instead, before anything is published anywhere.
+      # The description cap is checked here too. The registry enforces it, but
+      # only at publish time and only with a 422 — by then npm has the release
+      # and the registry does not, which is the split this workflow exists to
+      # prevent. A 101-character description cost exactly that once.
       - name: Fail if the three versions disagree
         env:
           TAG: ${{ github.ref_name }}
@@ -58,6 +62,10 @@ jobs:
           if (values.length > 1) {
             console.error("Version mismatch:");
             for (const [where, v] of Object.entries(seen)) console.error(`  ${where}: ${v}`);
+            process.exit(1);
+          }
+          if (srv.description.length > 100) {
+            console.error(`server.json description is ${srv.description.length} characters; the registry rejects anything over 100.`);
             process.exit(1);
           }
           console.log(`All versions agree on ${values[0]}.`);'

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.erayendes/asc-mcp",
-  "description": "App Store Connect + StoreKit 2 from any AI client. 868 tools across 13 curated profiles, safe writes.",
+  "description": "App Store Connect + StoreKit 2 from any AI client. 868 tools in 13 curated profiles, safe writes.",
   "repository": {
     "url": "https://github.com/erayendes/app-store-connect-mcp",
     "source": "github"


### PR DESCRIPTION
The 2.0.0 publish to the MCP Registry failed:

```
422 Unprocessable Entity
{"message":"expected length <= 100","location":"body.description",
 "value":"App Store Connect + StoreKit 2 from any AI client. 868 tools across 13 curated profiles, safe writes."}
```

101 characters. The description I wrote in #39 was one over. Swapping `across` for `in` leaves 97 and says the same thing.

**The check from #40 now covers length too.** The registry does enforce the cap — but only at publish time, and by then npm already has the release and the registry does not. That split is the entire reason #40 exists, so the cheap pre-flight check should catch this class as well as version drift.

Verified both directions against the real files:

| Input | Result |
|---|---|
| current 97-character description | `All versions agree on 2.0.0.` exit 0 |
| the exact 101-character string that drew the 422 | exit 1, `server.json description is 101 characters; the registry rejects anything over 100.` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)