### PR TITLE
fix(deps): bump nanoid past GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2970,9 +2970,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes Scorecard alert 6 (high): `nanoid` before 3.3.17 can loop indefinitely when a custom generator is given size zero.

Nothing in this repo calls it. It arrives five levels down a dev-only chain — `vitest` → `vite` → `postcss` → `nanoid` — and `npm ls nanoid --omit=dev` is empty, so it has never been part of anything published (the package ships `dist`, `skills` and the docs). The alert is accurate about the lockfile and not about the product.

`package-lock.json` only: 3.3.16 → 3.3.18, three lines. `vitest`, `vite` and `postcss` are unmoved, and the lockfile's own version fields stay at 2.1.0 so the release pre-flight still agrees. `npm audit` reports 0 vulnerabilities and the full suite passes.