### PR TITLE
fix: generate the throwaway key instead of committing it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 # Dockerfile — used only for automated introspection (Glama / MCP Registry checks).
 # It boots the MCP server so a harness can call tools/list. The ASC_* values below are
-# throwaway placeholders: a self-generated EC key that is NOT registered with Apple and
-# authorizes nothing — it only lets the server start for introspection (which never calls
-# Apple). Real users configure credentials via `npx -y @erayendes/asc-mcp setup`; see README.
+# throwaway placeholders: the key is generated during the build, is NOT registered with
+# Apple and authorizes nothing — it only lets the server start for introspection (which
+# never calls Apple). Real users configure credentials via `npx -y @erayendes/asc-mcp
+# setup`; see README.
+#
+# Generated rather than pasted. The literal that used to sit here was inert, and it was
+# still a PEM in a public repository: every secret scanner flags one, and a reader has to
+# take "throwaway" on trust. A fresh key per build costs nothing and claims nothing.
 FROM node:26-alpine@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781b51f6a0b019
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -11,7 +16,12 @@ COPY . .
 RUN npm run build
 ENV ASC_KEY_ID=AAAAAAAAAA
 ENV ASC_ISSUER_ID=00000000-0000-0000-0000-000000000000
-ENV ASC_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgB0n4fZRe2byJJ1e0\nKwadtouzBaZznbVIpcOyQOML5J+hRANCAAR69v/Z9bUioOKj8f0ld8f0/dGjn0fJ\nNyaO0nme1OCqeX8xqdTd1/5eDEgWtUHxvBpTmKz1fz3SI69W9kOcJYF7\n-----END PRIVATE KEY-----\n"
+# node, not openssl: the CLI is not in node:*-alpine, and node is the one thing
+# every stage here already depends on.
+RUN node -e "const {generateKeyPairSync}=require('node:crypto'); \
+  const {privateKey}=generateKeyPairSync('ec',{namedCurve:'prime256v1'}); \
+  require('node:fs').writeFileSync('/app/introspection-key.pem', privateKey.export({type:'pkcs8',format:'pem'}));"
+ENV ASC_PRIVATE_KEY_PATH=/app/introspection-key.pem
 # A profile, because that is how the server is meant to be run: `setup` writes one,
 # the guide documents one, and the whole surface at once is the configuration the docs
 # warn against. Booting bare showed introspection a shape no real install has.

--- a/assets/demo/demo.tape
+++ b/assets/demo/demo.tape
@@ -5,13 +5,14 @@
 # in for Apple so the GIF can be public without confirming what a real account
 # holds. Playback is sped up; the session takes about 20 seconds in real time.
 #
-# assets/demo/mcp-config.json carries an EC private key. It is a throwaway,
-# not registered with Apple, and authorizes nothing — the same key and the same
-# reasoning as the Dockerfile, which needs a bootable server for directory
-# introspection. The fixture server never checks the JWT; the key exists only
-# so TokenProvider has something to sign with.
+# The server needs a key to start, because TokenProvider signs an ES256 JWT
+# per request — the fixture never checks it, but it has to be a real EC key.
+# One is generated below and written to assets/demo/demo-key.pem, which
+# .gitignore's *.pem already covers. Nothing about it is committed: a private
+# key in a public repo is inert here and still trips every scanner that sees
+# one, and a reader has to take "throwaway" on trust.
 #
-# Prerequisites: npm run build, and `vhs` on PATH (brew install vhs).
+# Prerequisites: npm run build, `vhs` on PATH (brew install vhs), openssl.
 
 Output assets/demo.gif
 
@@ -30,6 +31,8 @@ Hide
 Type "cd $PWD"
 Enter
 Type "lsof -ti tcp:8787 | xargs -r kill -9 2>/dev/null; sleep 1"
+Enter
+Type "openssl ecparam -genkey -name prime256v1 -noout | openssl pkcs8 -topk8 -nocrypt -out assets/demo/demo-key.pem"
 Enter
 Type "setopt interactive_comments; node assets/demo/fixture-server.mjs 8787 >/dev/null 2>&1 &!"
 Enter

--- a/assets/demo/mcp-config.json
+++ b/assets/demo/mcp-config.json
@@ -8,7 +8,7 @@
         "ASC_BASE_URL": "http://127.0.0.1:8787",
         "ASC_KEY_ID": "AAAAAAAAAA",
         "ASC_ISSUER_ID": "00000000-0000-0000-0000-000000000000",
-        "ASC_PRIVATE_KEY": "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgB0n4fZRe2byJJ1e0\nKwadtouzBaZznbVIpcOyQOML5J+hRANCAAR69v/Z9bUioOKj8f0ld8f0/dGjn0fJ\nNyaO0nme1OCqeX8xqdTd1/5eDEgWtUHxvBpTmKz1fz3SI69W9kOcJYF7\n-----END PRIVATE KEY-----\n"
+        "ASC_PRIVATE_KEY_PATH": "assets/demo/demo-key.pem"
       }
     }
   }


### PR DESCRIPTION
Two places need a bootable server and both carried the same EC private key as a literal: the `Dockerfile` since it was written, and `assets/demo/mcp-config.json` for the README recording.

The key is genuinely inert — not registered with Apple, paired with key id `AAAAAAAAAA` and an all-zero issuer, and in the demo's case pointed at a fixture server on `127.0.0.1`. It is also a PEM in a public repository, which every secret scanner flags and which a reader has to take on trust. Neither cost is worth paying for a value that takes one line to produce.

The server needs a real EC key regardless, because `TokenProvider` signs an ES256 JWT per request whether or not anything checks it. So both sides generate one:

- the `Dockerfile` at build time, with `node` rather than `openssl`, which is not in `node:*-alpine`
- `demo.tape` before it starts the fixture server, into `assets/demo/demo-key.pem`, which `.gitignore`'s `*.pem` already covers

Both then point `ASC_PRIVATE_KEY_PATH` at the file. No PEM literal is left in the repository outside the truncated `MIG...` placeholders in `.env.example` and the keychain tests.

**Verified:** the generation snippet produces a pkcs8 EC key, and the server boots from `ASC_PRIVATE_KEY_PATH` with those placeholder ids — `asc-distribution (129 tools) v2.1.0 ready`. Full suite passes.

**Not verified:** the image itself. There is no Docker on the machine this was written on, so the `RUN node -e ...` step has not been executed inside `node:26-alpine`.

The recordings are unaffected — the key never appeared on screen.