### PR TITLE
docs: trim the README and the 2.1.0 changelog entry

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -16,6 +16,17 @@ The best habit, with this project or any other, is to check it before you trust 
 - **The tools are generated, not hand-written**, from Apple's OpenAPI spec (`spec/openapi.json`) by `scripts/generate.ts` — so what you audit is what runs.
 - **Pin a reviewed version** if you want to be strict: `npx -y @erayendes/asc-mcp@1.0.4 …`.
 
+### How the package reaches you
+
+Auditing the source only helps if the published package is built from it. The release pipeline is what connects the two, and all of it is verifiable without taking anyone's word for it.
+
+- **Published by GitHub Actions, not by a person.** npm trusted publishing (OIDC) issues a short-lived credential per release, so there is no long-lived npm token in this repository, in CI secrets, or on a maintainer's laptop to steal.
+- **Signed provenance.** Every release is published with `--provenance`, so npm records which workflow, which commit and which repository produced the tarball. `npm view @erayendes/asc-mcp` shows the attestation.
+- **An SBOM per release.** Each GitHub release carries an SPDX bill of materials for the production dependency tree.
+- **Actions pinned to commit SHAs**, so a compromised or retagged third-party action cannot change what runs in the release job. Dependabot raises the bumps as reviewable pull requests.
+- **Dependency review on every pull request**, failing on moderate severity and above.
+- **Release metadata is cross-checked before publishing.** The version has to agree across `package.json`, `server.json`, `package-lock.json`, `CITATION.cff` and the git tag, and the changelog has to carry a matching heading, or the release stops.
+
 ### What we collect: nothing
 
 Heimdall has **no backend and no telemetry**. There is nothing to opt out of.
@@ -77,6 +88,17 @@ En iyi alışkanlık, bu projede ya da başka herhangi birinde, güvenmeden önc
 
 - **Araçlar elle değil üretilerek** gelir; Apple'ın OpenAPI spec'inden (`spec/openapi.json`) `scripts/generate.ts` ile — yani denetlediğiniz şey, çalışan şeydir.
 - Katı olmak isterseniz **incelediğiniz bir sürüme sabitleyin**: `npx -y @erayendes/asc-mcp@1.0.4 …`.
+
+### Paket size nasıl ulaşıyor
+
+Kaynağı denetlemek, ancak yayınlanan paket ondan üretiliyorsa işe yarar. İkisini birbirine bağlayan şey yayın hattı ve hepsi kimsenin sözüne güvenmeden doğrulanabilir.
+
+- **Bir insan değil, GitHub Actions yayınlıyor.** npm trusted publishing (OIDC) her sürüm için kısa ömürlü bir kimlik üretiyor; yani ne bu depoda, ne CI secret'larında, ne de bir geliştiricinin dizüstünde çalınacak uzun ömürlü bir npm token'ı var.
+- **İmzalı provenance.** Her sürüm `--provenance` ile yayınlanıyor; npm, tarball'ı hangi workflow'un, hangi commit'in ve hangi deponun ürettiğini kaydediyor. `npm view @erayendes/asc-mcp` attestation'ı gösterir.
+- **Sürüm başına SBOM.** Her GitHub release'i, üretim bağımlılık ağacı için SPDX malzeme listesi taşıyor.
+- **Action'lar commit SHA'sına sabitlenmiş**, yani ele geçirilmiş ya da yeniden etiketlenmiş bir üçüncü taraf action yayın işinde çalışanı değiştiremiyor. Güncellemeleri Dependabot incelenebilir pull request'ler olarak açıyor.
+- **Her pull request'te dependency review**, orta ve üzeri önem derecesinde başarısız oluyor.
+- **Yayından önce sürüm verileri çapraz kontrol ediliyor.** Sürüm numarası `package.json`, `server.json`, `package-lock.json`, `CITATION.cff` ve git etiketi arasında uyuşmak zorunda, changelog'da eşleşen bir başlık bulunmak zorunda — yoksa yayın durur.
 
 ### Ne topluyoruz: hiçbir şey
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,11 @@ jobs:
           // different numbers (868/875/883) before this check existed. README is
           // the source of truth because it is regenerated against the code.
           const readme = fs.readFileSync("README.md", "utf8");
-          const counts = { "README.md": (readme.match(/([0-9]{3,4}) tools\./) || [])[1], "server.json": (srv.description.match(/([0-9]{3,4}) tools/) || [])[1], "CITATION.cff": (citation.match(/with ([0-9]{3,4}) tools/) || [])[1] };
+          // README is bilingual and the English half is not the whole claim: the
+          // count is advertised again as "N araç" in the Turkish section, and a
+          // guard that reads only one half lets the two drift apart silently —
+          // which is the exact failure this check exists to prevent.
+          const counts = { "README.md (en)": (readme.match(/([0-9]{3,4}) tools\./) || [])[1], "README.md (tr)": (readme.match(/([0-9]{3,4}) ara\u00e7/) || [])[1], "server.json": (srv.description.match(/([0-9]{3,4}) tools/) || [])[1], "CITATION.cff": (citation.match(/with ([0-9]{3,4}) tools/) || [])[1] };
           const distinct = [...new Set(Object.values(counts))];
           if (distinct.length > 1 || !distinct[0]) {
             console.error("Tool count mismatch across advertised surfaces:");

--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/%40erayendes%2Fasc-mcp.svg)](https://www.npmjs.com/package/@erayendes/asc-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/%40erayendes%2Fasc-mcp.svg)](https://www.npmjs.com/package/@erayendes/asc-mcp)
 [![CI](https://github.com/erayendes/app-store-connect-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/erayendes/app-store-connect-mcp/actions/workflows/ci.yml)
-[![Glama](https://img.shields.io/badge/Glama-listed-8A2BE2)](https://glama.ai/mcp/servers/bwyd9qd63y)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Node](https://img.shields.io/badge/node-%3E%3D20.19-brightgreen.svg)](package.json)
-[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-orange.svg)](https://buymeacoffee.com/erayendes)
 [![Yerli üretim](https://img.shields.io/badge/%F0%9F%A4%9D-YERL%C4%B0%20%C3%9CRET%C4%B0M-red)](https://github.com/erayendes)
 
 <!-- Absolute URL on purpose: npm does not rewrite relative image paths. -->
@@ -31,6 +28,16 @@ Apps and metadata, versions and phased releases, TestFlight, subscriptions and i
 > - *"Summarise this week's 1-star reviews and draft replies."*
 > - *"Which builds are stuck in review?"*
 > - *"Raise this subscription's price in every territory."*
+
+### What the one call saves
+
+| The question | Through the raw tools | Heimdall |
+|:--|:--|:--|
+| *"What does this subscription cost in every country?"* | one measured agent session: 1.02M tokens, $3 | ~1.3k tokens, 2.1s |
+| *"What screenshots are on the listing?"* | 53 HTTP calls, 264 KB | 4 calls, ~1 KB |
+| *"Change this subscription's price."* | 4 reads, then a choice among 842 price points | one call |
+
+The first row is a real session, not a projection: the agent walked the chain, could not fit the answer, wrote it to a CSV and hand-built a country-name dictionary in Python to finish. The other two are call counts against a live account.
 
 ### Quick start
 
@@ -123,6 +130,16 @@ Uygulamalar ve metadata, sürümler ve kademeli yayınlar, TestFlight, abonelikl
 > - *"Bu haftanın 1 yıldızlı yorumlarını özetle ve cevap taslakları hazırla."*
 > - *"Hangi build'ler incelemede takıldı?"*
 > - *"Bu aboneliğin fiyatını her ülkede artır."*
+
+### Tek çağrının kazandırdığı
+
+| Soru | Ham araçlarla | Heimdall |
+|:--|:--|:--|
+| *"Bu abonelik her ülkede kaça?"* | ölçülen bir ajan oturumu: 1,02M token, 3 $ | ~1,3k token, 2,1 sn |
+| *"Mağaza sayfasında hangi ekran görüntüleri var?"* | 53 HTTP çağrısı, 264 KB | 4 çağrı, ~1 KB |
+| *"Bu aboneliğin fiyatını değiştir."* | 4 okuma, sonra 842 fiyat noktası içinden seçim | tek çağrı |
+
+İlk satır tahmin değil, gerçek bir oturum: ajan zinciri yürüdü, cevap sığmayınca bir CSV'ye yazdı ve bitirebilmek için Python'da elle ülke adı sözlüğü kurdu. Diğer ikisi canlı bir hesapta çağrı sayımı.
 
 ### Hızlı başlangıç
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,9 @@ An MCP server for the **App Store Connect API** and the **App Store Server API (
 Apps and metadata, versions and phased releases, TestFlight, subscriptions and in-app purchases, pricing, reviews, Game Center, Xcode Cloud, provisioning, webhooks, and sales and finance reports.
 
 ### Ask and it answers. Tell it and it's done.
-
 > - *"Summarise this week's 1-star reviews and draft replies."*
 > - *"Which builds are stuck in review?"*
 > - *"Raise this subscription's price in every territory."*
-
-> [!IMPORTANT]
-> **2.0.0 is a breaking release.** Which tool belongs to which profile is hand-curated now, so every profile's contents changed and `user-management` was split into four. Nothing was lost, but the tool you reach for may have moved next door. Upgrading from 1.x: check the profile names in your config against the [changelog](docs/CHANGELOG.md).
 
 ### Quick start
 
@@ -45,11 +41,10 @@ npx -y @erayendes/asc-mcp setup
 <!-- Absolute URL on purpose: npm does not rewrite relative image paths. -->
 <img src="https://raw.githubusercontent.com/erayendes/app-store-connect-mcp/main/assets/setup.gif" alt="The setup wizard: key, issuer ID, credential check, profile and sub-profile selection, key stored in the Keychain" width="720">
 
-<sub>One pass: the key and issuer ID, a live credential check, then the profiles and sub-profiles you want — and the key ends up in the Keychain, not in a config file. Sped up; invented credentials against a stand-in API.</sub>
+<sub>One pass, and safe throughout: the access details it needs, then a live credential check. Then your choices — the profiles and sub-profiles you want, and the key ends up in the Keychain, not in a config file.</sub>
 
-The setup wizard asks for your API key once, stores it safely, and registers the profiles you choose with **every MCP client on your machine** — Claude, Codex, Antigravity, Cursor, Windsurf, VS Code. None of them share a config file, so this is the step you would otherwise repeat once per client, in a different format each time. Full walkthrough in the [Guide](docs/GUIDE.md).
-
-> [!NOTE]
+The setup wizard asks for your API key once, stores it safely, and registers the profiles you choose with **every MCP client on your machine** — Claude, Codex, Antigravity, Cursor, Windsurf, VS Code. None of them share a config file, so **this is the step you would otherwise repeat once per client, in a different format each time.** Time thrown away.
+Full walkthrough in the [Guide](docs/GUIDE.md).
 > **Is an AI agent installing Heimdall for you?**
 > See [AGENTS.md](AGENTS.md) for the handoff protocol: the agent adds the profiles with `register`, you run `setup` yourself for the key — your private key is for your eyes only, and the agent never sees it.
 
@@ -66,12 +61,9 @@ Most App Store Connect MCP servers offer a hand-picked slice of the API. That wo
 | **Safe** | Confirm-before-write, `--read-only`, destructive-action annotations, host-pinned requests, no telemetry. |
 | **Private** | The `.p8` lives in the macOS Keychain, never in a plain-text config. |
 
+#### Profiles
 <!-- Absolute URL on purpose: npm does not rewrite relative image paths. -->
 <img src="https://raw.githubusercontent.com/erayendes/app-store-connect-mcp/main/assets/picker.gif" alt="The profile picker: checking monetization unfolds its sub-profiles, each with its tool count and token estimate" width="720">
-
-<sub>Checking a profile unfolds its sub-profiles, each with what it costs a session. Uncheck what this job does not need — no config file, no restart to find out.</sub>
-
-#### Profiles
 
 Register only the profiles your project uses. What each one covers is in the [profile table](docs/GUIDE.md#register-profiles); adding and removing them later is [here](docs/GUIDE.md#adding-and-removing-later).
 
@@ -83,9 +75,7 @@ Changing a price, submitting for review or deleting something can ask for confir
 
 #### Local by design, not by default
 
-MCP guidance recommends remote HTTP servers: one URL, no install, updates you control. Heimdall runs locally over stdio instead, and that is a deliberate trade.
-
-A remote Heimdall would have to hold your `.p8` — the private key that signs every App Store Connect request, with whatever role you granted it. Hosting it means asking every user to hand their App Store account's signing key to a third party, and making that server a target worth attacking. Running locally, the key never leaves your machine: Heimdall reads it from the Keychain, signs a short-lived token, and talks to Apple directly. Nothing sits in between.
+MCP guidance recommends remote HTTP servers: one URL, no install, updates you control. Heimdall runs locally over stdio instead, and that is a deliberate trade. Running locally, the key never leaves your machine: Heimdall reads it from the Keychain, signs a short-lived token, and talks to Apple directly. Nothing sits in between.
 
 The cost is real and worth naming: you need Node installed, and you update by version rather than by us pushing one. That is the price of the key staying yours.
 
@@ -130,13 +120,9 @@ Tool definitions in `src/generated/` are produced from Apple Inc.'s published Ap
 Uygulamalar ve metadata, sürümler ve kademeli yayınlar, TestFlight, abonelikler ve uygulama içi satın almalar, fiyatlandırma, yorumlar, Game Center, Xcode Cloud, provisioning, webhook'lar, satış ve finans raporları.
 
 ### Sorun yanıtlasın. İsteyin yapsın.
-
 > - *"Bu haftanın 1 yıldızlı yorumlarını özetle ve cevap taslakları hazırla."*
 > - *"Hangi build'ler incelemede takıldı?"*
 > - *"Bu aboneliğin fiyatını her ülkede artır."*
-
-> [!IMPORTANT]
-> **2.0.0 kırıcı bir sürümdür.** Hangi aracın hangi profile ait olduğu artık elle belirleniyor; bu yüzden her profilin içeriği değişti ve `user-management` dörde bölündü. Hiçbir araç kaybolmadı, ama aradığınız araç yan komşuya taşınmış olabilir. 1.x'ten yükseltiyorsanız config'inizdeki profil adlarını [değişiklik günlüğüyle](docs/CHANGELOG.md) karşılaştırın.
 
 ### Hızlı başlangıç
 
@@ -147,11 +133,10 @@ npx -y @erayendes/asc-mcp setup
 <!-- Absolute URL on purpose: npm does not rewrite relative image paths. -->
 <img src="https://raw.githubusercontent.com/erayendes/app-store-connect-mcp/main/assets/setup.gif" alt="Setup sihirbazı: anahtar, issuer ID, istemci seçimi, profil seçimi ve yazmadan önce onay" width="720">
 
-<sub>Tek geçiş: anahtar ve issuer ID, canlı kimlik doğrulama, sonra istediğiniz profiller ve alt profiller — anahtar da config dosyasına değil Keychain'e gidiyor. Hızlandırılmış; uydurma kimlik bilgileriyle, Apple yerine bir taklit sunucuya karşı.</sub>
+<sub>Tek geçiş ve şahane güvenlik: Gerekli erişim bilgileri, sonra canlı kimlik doğrulama. Ardından seçimleriniz; istediğiniz profiller ve alt profiller — anahtar da config dosyasına değil Keychain'e gidiyor.</sub>
 
-Setup sihirbazı API anahtarınızı bir kez ister, güvenle saklar ve seçtiğiniz profilleri **makinenizdeki bütün MCP istemcilerine** kaydeder — Claude, Codex, Antigravity, Cursor, Windsurf, VS Code. Hiçbiri config dosyasını paylaşmaz; yani bu adım olmasa her istemci için ayrı ayrı, her seferinde farklı biçimde tekrarlanırdı. Adım adım anlatım [Rehber](docs/GUIDE.md)'de.
-
-> [!NOTE]
+Setup sihirbazı API anahtarınızı bir kez ister, güvenle saklar ve seçtiğiniz profilleri **makinenizdeki bütün MCP istemcilerine** kaydeder — Claude, Codex, Antigravity, Cursor, Windsurf, VS Code. Hiçbiri config dosyasını paylaşmaz; **yani bu adım olmasa her istemci için ayrı ayrı, her seferinde farklı biçimde tekrarlanırdı.** Boşa vakit kaybı. 
+Adım adım anlatım [Rehber](docs/GUIDE.md)’de.
 > **Heimdall'ı bir AI agent mı kuracak?**
 > Devir protokolü için [AGENTS.md](AGENTS.md)'ye bakın: agent profilleri `register` ile ekler, anahtar için `setup`'ı siz çalıştırırsınız — özel anahtarınız sadece sizin gözleriniz için, AI agent göremez.
 
@@ -168,14 +153,11 @@ Setup sihirbazı API anahtarınızı bir kez ister, güvenle saklar ve seçtiği
 | **Güvenli** | Yazmadan-önce onay, `--read-only`, yıkıcı işlem etiketleri, host'a sabitlenmiş istekler, telemetri yok. |
 | **Gizli** | `.p8` macOS Keychain'de durur, düz metin config'de değil. |
 
+#### Profiller
 <!-- Absolute URL on purpose: npm does not rewrite relative image paths. -->
 <img src="https://raw.githubusercontent.com/erayendes/app-store-connect-mcp/main/assets/picker.gif" alt="Profil seçici: monetization işaretlenince alt profilleri araç sayısı ve token tahminiyle açılıyor" width="720">
 
-<sub>Bir profili işaretleyince alt profilleri açılıyor, her biri oturuma maliyetiyle birlikte. Bu iş için gerekmeyeni kaldırın — config dosyası yok, öğrenmek için yeniden başlatma yok.</sub>
-
-#### Profiller
-
-Sadece projenizin kullandığı profilleri kaydedin. Hangisinin neyi kapsadığı [profil tablosunda](docs/GUIDE.md#profilleri-kaydedin), sonradan ekleme ve çıkarma [burada](docs/GUIDE.md#sonradan-ekleme-ve-çıkarma)'de.
+Sadece projenizin kullandığı profilleri kaydedin. Hangisinin neyi kapsadığı [profil tablosunda](docs/GUIDE.md#profilleri-kaydedin), sonradan ekleme ve çıkarma [burada](docs/GUIDE.md#sonradan-ekleme-ve-çıkarma).
 
 Hiçbir şeyi ezberlemeniz gerekmez — *"uygulama içi etkinlikler için bir araç var mı?"* diye sorun; `asc__search_tools` o an yüklü olmayanlar dahil hepsini arar ve hangi profilde olduğunu söyler.
 
@@ -185,9 +167,7 @@ Fiyat değiştirme, incelemeye gönderme ya da bir şeyi silme çalışmadan ön
 
 #### Yerelde çalışması tercih, eksiklik değil
 
-MCP rehberleri uzak HTTP sunucularını önerir: tek URL, kurulum yok, güncellemeyi siz yönetirsiniz. Heimdall bunun yerine yerelde stdio üzerinden çalışır ve bu bilinçli bir tercihtir.
-
-Uzak bir Heimdall, `.p8` dosyanızı tutmak zorunda kalırdı — her App Store Connect isteğini imzalayan, verdiğiniz role sahip özel anahtar. Onu barındırmak, her kullanıcıdan App Store hesabının imza anahtarını üçüncü bir tarafa teslim etmesini istemek ve o sunucuyu saldırmaya değer bir hedef hâline getirmek demektir. Yerelde çalışınca anahtar makinenizden hiç çıkmaz: Heimdall onu Keychain'den okur, kısa ömürlü bir token imzalar ve doğrudan Apple ile konuşur. Arada hiçbir şey durmaz.
+MCP rehberleri uzak HTTP sunucularını önerir: tek URL, kurulum yok, güncellemeyi siz yönetirsiniz. Heimdall bunun yerine yerelde stdio üzerinden çalışır ve bu bilinçli bir tercihtir. Yerelde çalışınca anahtar makinenizden hiç çıkmaz: Heimdall onu Keychain'den okur, kısa ömürlü bir token imzalar ve doğrudan Apple ile konuşur. Arada hiçbir şey durmaz.
 
 Bedeli gerçek ve söylenmeye değer: Node kurulu olmalı ve güncelleme biz gönderdiğimiz için değil, siz sürüm seçtiğiniz için gelir. Anahtarın sizde kalmasının bedeli bu.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Most App Store Connect MCP servers offer a hand-picked slice of the API. That wo
 | | |
 | :--- | :--- |
 | **Complete** | Apple's OpenAPI spec v4.4.1, all 966 paths, 982 operations — 281 id-only duplicates already collapsed, and the 123 Apple has deprecated stay unloaded unless you ask for them, which leaves the 859 reachable operations plus 24 hand-written tools. `npm run spec:update` brings Apple's changes in as a reviewable diff. |
-| **Narrowable** | 13 purpose-built profiles, each narrowing further — `monetization:subscription-pricing` is 24 tools instead of 204. The whole surface would cost over 100k tokens of tool definitions; one profile costs a fraction of that. |
+| **Narrowable** | 13 purpose-built profiles, each narrowing further — `monetization:subscription-pricing` is 26 tools instead of 206. The whole surface would cost over 100k tokens of tool definitions; one profile costs a fraction of that. |
 | **StoreKit 2** | The App Store Server API too — customer transactions, entitlements, refunds. **Rare among ASC MCP servers.** |
 | **No second API key** | Review triage, daily briefings and draft replies return the review data — your own model writes the text. |
 | **Safe** | Confirm-before-write, `--read-only`, destructive-action annotations, host-pinned requests, no telemetry. |
@@ -164,7 +164,7 @@ Adım adım anlatım [Rehber](docs/GUIDE.md)’de.
 | | |
 | :--- | :--- |
 | **Eksiksiz** | Apple'ın OpenAPI spec v4.4.1'i, tüm 966 path, 982 işlem — 281 id-only tekrar zaten birleştirilmiş durumda, Apple'ın kullanımdan kaldırdığı 123 işlem de siz istemedikçe yüklenmiyor; geriye erişilebilir 859 işlem artı elle yazılmış 24 araç kalıyor. `npm run spec:update` Apple'ın değişikliklerini gözden geçirilebilir bir diff olarak getirir. |
-| **Daraltılabilir** | 13 amaca özel profil, her biri daha da daralabilir — `monetization:subscription-pricing` 204 yerine 24 araç. Tüm yüzey araç tanımları için 100 bin token'ı aşar; bir profil bunun küçük bir kısmı. |
+| **Daraltılabilir** | 13 amaca özel profil, her biri daha da daralabilir — `monetization:subscription-pricing` 206 yerine 26 araç. Tüm yüzey araç tanımları için 100 bin token'ı aşar; bir profil bunun küçük bir kısmı. |
 | **StoreKit 2** | App Store Server API de var — tüm müşteri işlemleri, haklar, iadeler. **ASC MCP sunucuları arasında nadir bir özellik.** |
 | **İkinci API anahtarı yok** | Yorum tasnifi, günlük brifing ve cevap taslakları yorum verisini döndürür — metni kendi modeliniz yazar. |
 | **Güvenli** | Yazmadan-önce onay, `--read-only`, yıkıcı işlem etiketleri, host'a sabitlenmiş istekler, telemetri yok. |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,21 +14,6 @@ Every mutating operation already carried a hand-reviewed risk level, but it only
 - **`destructiveHint` now means what MCP says it means**, "may perform destructive updates", not "is a DELETE". **Clients that gate on this hint will ask for approval on more tools than before.**
 - `app_store_versions__build__set` was classified `low` because the release rule matched only `create|update`. Swapping the binary under a version is a release step.
 
-#### Documentation
-The README advertised **868 tools** and "nine hand-written tools". Both were already wrong before this release — the count of hand-written tools left out the `reviews_ai__*` and `storekit__*` families entirely. It is 859 reachable operations plus 24 hand-written tools, 883 in total.
-
-Three profile counts in the guide moved with this release: `analytics` 23 → 24, `distribution` 127 → 129, `monetization` 204 → 206.
-
-`AGENTS.md` described `destructiveHint` as meaning deletes, which stopped being true in this release, and now points at the `heimdall` skill as the copy of itself that reaches users who install through `npx` and have no checkout. The guide gained a table of the macros, which had never been documented outside the changelog.
-
-The count is advertised on four surfaces and had drifted to three different numbers: `server.json` and `CITATION.cff` said 868, the GitHub repo description said 875, the README said 883. All now say 883, and `CITATION.cff` — which was two releases behind at 2.0.0 — is current.
-
-The release pre-flight now checks both, so this cannot drift again: `CITATION.cff` joins the six version fields it already compares, and the tool count is cross-checked between README, `server.json` and `CITATION.cff`. A mismatch fails the release instead of shipping.
-
-The MCP Registry description spent its 100-character budget on a wrong number and the phrase "safe writes", which distinguishes Heimdall from nothing — several App Store Connect servers list the same claim. It now leads with the thing none of them have: `Every App Store Connect + StoreKit 2 endpoint. 883 tools in 13 profiles, narrow to 24.`
-
-`.claude-plugin/plugin.json` pointed its homepage at `erayendes/asc-mcp`, a repository that does not exist.
-
 #### `pricing__equalize_price` — one anchor price, every country derived by Apple
 For an app, an in-app purchase or a subscription. Give the anchor territory and the price; Apple's own currency and tax maths decides every other market. The number is never copied across currencies, because it cannot be — anchored at 3.99 TRY, Apple returns 0.99 USD for Afghanistan and 2.99 AED for the UAE.
 
@@ -62,9 +47,11 @@ Both were chains that ended somewhere the API does not go.
 - **`listing__get_screenshots` shipped in 2.0.0 unreachable.** Its family was missing from the profile generator's known list, so no row for it could exist in the curation sheet and no profile-mode server offered it. Both listing macros now live under `distribution:version`. `pricing__get_subscription_price` was missing a row too — it worked, but the per-sub-profile tool counts were short by one.
 - **`review_submissions__create` was described as submitting a version for review.** It takes an *app*, not a version, and opens an empty submission; the version goes in as a separate item and nothing reaches Apple until `submitted` is set. An agent that stopped after the first call reported a release it had not shipped. The three steps now each say what they are not.
 - Curated descriptions for the review-submission chain and both ends of the analytics chain; AXIS1 findability debt 718 → 712.
+- **The tool count had drifted to three numbers across four surfaces** — `server.json` and `CITATION.cff` said 868, the GitHub repo description 875, the README 883 — and `CITATION.cff` was two releases behind at 2.0.0. All now say 883 (859 reachable operations plus 24 hand-written tools), and the release pre-flight compares the `CITATION.cff` version and the tool count on all three surfaces, failing the release on a mismatch instead of shipping it.
+- **`.claude-plugin/plugin.json` pointed its homepage at `erayendes/asc-mcp`**, a repository that does not exist.
 
 #### For contributors
-- **`npm run ax:agent` did not run at all** — it read a field the `Profile` type does not have and threw on import.
+- **`npm run ax:agent` did not run** — it read a field the `Profile` type does not have and threw on import.
 - `--skill=<dir>` and `--wrong-profile` for A/B-ing a skill document, with per-session `reachedForCredentials` / `calledAppleDirectly` booleans and a `By skill` table printed as deltas against the control arm. `SHELL_KINDS` was undercounting: `security find-generic-password` and a bare `curl` at Apple were only recorded when piped through a filter word.
 
 #### Added
@@ -202,21 +189,6 @@ Her mutasyon operasyonu zaten elle gözden geçirilmiş bir risk seviyesi taşı
 - **`destructiveHint` artık MCP'nin söylediği anlama geliyor**: "yıkıcı güncelleme yapabilir", "DELETE'tir" değil. **Bu ipucuna göre onay isteyen istemciler eskisinden daha fazla araçta soracak.**
 - `app_store_versions__build__set`, release kuralı yalnızca `create|update` ile eşleştiği için `low` sayılıyordu. Bir sürümün altındaki binary'yi değiştirmek bir yayın adımıdır.
 
-#### Dokümantasyon
-README **868 araç** ve "elle yazılmış dokuz araç" diyordu. İkisi de bu sürümden önce zaten yanlıştı — elle yazılmış araç sayısı `reviews_ai__*` ve `storekit__*` ailelerini hiç saymıyordu. Doğrusu: erişilebilir 859 işlem artı elle yazılmış 24 araç, toplam 883.
-
-Bu sürümle birlikte kılavuzdaki üç profil sayısı değişti: `analytics` 23 → 24, `distribution` 127 → 129, `monetization` 204 → 206.
-
-`AGENTS.md`, `destructiveHint`'i silme işlemleri olarak tarif ediyordu; bu sürümde doğru olmaktan çıktı. Artık `npx` ile kuran ve checkout'u olmayan kullanıcılara ulaşan kopyası olarak `heimdall` skill'ine işaret ediyor. Kılavuza, changelog dışında hiç belgelenmemiş olan makroların tablosu eklendi.
-
-Sayı dört yüzeyde duyuruluyor ve üç ayrı değere kaymıştı: `server.json` ile `CITATION.cff` 868, GitHub repo açıklaması 875, README 883 diyordu. Hepsi artık 883, ve 2.0.0'da kalarak iki sürüm geride kalan `CITATION.cff` güncellendi.
-
-Yayın öncesi kontrol artık ikisini de denetliyor, yani bu bir daha kayamaz: `CITATION.cff` zaten karşılaştırılan altı sürüm alanına katıldı ve araç sayısı README, `server.json` ve `CITATION.cff` arasında çapraz kontrol ediliyor. Uyuşmazlık yayını geçirmek yerine durduruyor.
-
-MCP Registry açıklaması 100 karakterlik bütçesini yanlış bir sayıya ve hiçbir şeyi ayırt etmeyen "safe writes" ifadesine harcıyordu — birkaç App Store Connect sunucusu aynı şeyi yazıyor. Artık hiçbirinde olmayan şeyle başlıyor: `Every App Store Connect + StoreKit 2 endpoint. 883 tools in 13 profiles, narrow to 24.`
-
-`.claude-plugin/plugin.json` homepage alanı var olmayan bir depoyu, `erayendes/asc-mcp`'yi gösteriyordu.
-
 #### `pricing__equalize_price` — tek çapa fiyat, her ülkeyi Apple türetiyor
 Uygulama, uygulama içi satın alma veya abonelik için. Çapa ülkeyi ve fiyatı verirsiniz; her pazarın karşılığını Apple'ın kendi kur ve vergi matematiği belirler. Sayı asla para birimleri arasında kopyalanmaz, çünkü kopyalanamaz — 3,99 TRY çapasında Apple Afganistan için 0,99 USD, BAE için 2,99 AED döndürüyor.
 
@@ -250,9 +222,11 @@ Tek ülke soran çağrılar değişmedi; yalnızca cevap ülkenin adını da ver
 - **`listing__get_screenshots` 2.0.0'da erişilemez olarak yayınlanmış.** Ailesi profil üreticisinin bilinen listesinde yoktu, dolayısıyla küratörlük sayfasında ona satır açılamıyordu ve hiçbir profil-modu sunucusu onu sunmuyordu. İki listing makrosu da artık `distribution:version` altında. `pricing__get_subscription_price` da sayfada yokmuş — çalışıyordu, ama alt profil araç sayıları birer eksik gösteriyordu.
 - **`review_submissions__create`, bir sürümü incelemeye gönderiyor diye anlatılıyordu.** Sürüm değil *uygulama* alıyor ve boş bir gönderim açıyor; sürüm ayrı bir kalem olarak ekleniyor ve `submitted` işaretlenene kadar Apple'a hiçbir şey ulaşmıyor. İlk çağrıdan sonra duran bir ajan, yapmadığı bir yayını yapılmış olarak raporluyordu. Üç adım artık ayrı ayrı ne *olmadıklarını* söylüyor.
 - İnceleme gönderim zinciri ve analiz zincirinin iki ucu için küratörlü açıklamalar; AXIS1 bulunabilirlik borcu 718 → 712.
+- **Araç sayısı dört yüzeyde üç ayrı değere kaymıştı** — `server.json` ve `CITATION.cff` 868, GitHub repo açıklaması 875, README 883 diyordu — ve `CITATION.cff` 2.0.0'da kalarak iki sürüm geride kalmıştı. Hepsi artık 883 (erişilebilir 859 işlem artı elle yazılmış 24 araç) ve yayın öncesi kontrol hem `CITATION.cff` sürümünü hem üç yüzeydeki araç sayısını karşılaştırıyor; uyuşmazlıkta yayını geçirmek yerine durduruyor.
+- **`.claude-plugin/plugin.json` homepage alanı** var olmayan bir depoyu, `erayendes/asc-mcp`'yi gösteriyordu.
 
 #### Katkıcılar için
-- **`npm run ax:agent` hiç çalışmıyordu** — `Profile` tipinde olmayan bir alanı okuyor ve import sırasında patlıyordu.
+- **`npm run ax:agent` çalışmıyordu** — `Profile` tipinde olmayan bir alanı okuyor ve import sırasında patlıyordu.
 - Bir skill belgesini A/B testine sokmak için `--skill=<dizin>` ve `--wrong-profile`; oturum başına `reachedForCredentials` / `calledAppleDirectly` boolean'ları ve kontrol koluna göre fark olarak basılan bir `By skill` tablosu. `SHELL_KINDS` eksik sayıyordu: `security find-generic-password` ve Apple'a atılan düz bir `curl`, ancak bir filtre kelimesine borulandığında kaydediliyordu.
 
 #### Eklendi

--- a/server.json
+++ b/server.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.erayendes/asc-mcp",
+  "title": "Heimdall",
   "description": "Every App Store Connect + StoreKit 2 endpoint. 883 tools in 13 profiles, narrow to 24.",
+  "websiteUrl": "https://github.com/erayendes/app-store-connect-mcp/blob/main/docs/GUIDE.md",
   "repository": {
     "url": "https://github.com/erayendes/app-store-connect-mcp",
     "source": "github"
@@ -10,11 +12,48 @@
   "packages": [
     {
       "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@erayendes/asc-mcp",
       "version": "2.1.0",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "valueHint": "profile",
+          "description": "Which slice of App Store Connect to serve. One of app-info, distribution, monetization, marketing, access, testflight, analytics, provisioning, game-center, app-clips, xcode-cloud, webhooks, background-assets. Narrow further with a colon — monetization:subscription-pricing is 26 tools instead of 206. Omit it to serve the default working set, which is larger.",
+          "isRequired": false
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "ASC_KEY_ID",
+          "description": "App Store Connect API Key ID. Normally written for you by `npx -y @erayendes/asc-mcp setup`.",
+          "isRequired": false
+        },
+        {
+          "name": "ASC_ISSUER_ID",
+          "description": "App Store Connect Issuer ID (a UUID). Normally written for you by `setup`.",
+          "isRequired": false
+        },
+        {
+          "name": "ASC_PRIVATE_KEY",
+          "description": "The .p8 private key as PEM text. Prefer `setup`, which stores it in the macOS Keychain instead of any config file; set this only where a Keychain is unavailable, such as CI.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "ASC_PRIVATE_KEY_PATH",
+          "description": "Path to the .p8 file, as an alternative to pasting its contents. Off macOS this is what `setup` records.",
+          "isRequired": false
+        },
+        {
+          "name": "ASC_BUNDLE_ID",
+          "description": "Bundle ID of one app. Only needed by the StoreKit 2 transaction tools on the monetization profile.",
+          "isRequired": false
+        }
+      ]
     }
   ]
 }

--- a/tests/profile-invariants.test.ts
+++ b/tests/profile-invariants.test.ts
@@ -4,6 +4,7 @@
  * curation can quietly get wrong — and did, before this file existed.
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
   PROFILES,
   PROFILE_DESCRIPTIONS,
@@ -11,6 +12,7 @@ import {
   CORE_MANUAL_TOOLS,
   REMOVED_PROFILES,
   descriptionKey,
+  manualToolsFor,
   operationsFor,
   removedProfileMessage,
   resolveSelection,
@@ -219,5 +221,59 @@ describe('counts — curation output, not something that drifts on its own', () 
     // It grew by 5 when the listing pair, the analytics macro, the equalize
     // macro and the missing pricing read joined the sheet.
     expect(new Set([...tools, ...CORE_OPERATIONS]).size).toBe(loadable.length + 18);
+  });
+});
+
+/**
+ * The registry entry advertises the profile list in prose, and prose does not
+ * regenerate. `server.json` is what every MCP aggregator scrapes, so a profile
+ * added or renamed here and not there is a wrong answer served hourly to every
+ * directory downstream — the same drift class the release pre-flight guards for
+ * the tool count.
+ */
+describe('server.json stays in step with the profiles', () => {
+  const server = JSON.parse(readFileSync('server.json', 'utf8'));
+  const profileArg = server.packages?.[0]?.packageArguments?.find(
+    (a: { valueHint?: string }) => a.valueHint === 'profile'
+  );
+
+  it('describes the profile argument at all', () => {
+    // Without it an installer runs the server with no profile and serves the
+    // default working set, which is the one thing the product is not about.
+    expect(profileArg, 'server.json declares no profile argument').toBeTruthy();
+    expect(profileArg.isRequired).toBe(false);
+  });
+
+  it('names every profile, and invents none', () => {
+    const described: string[] = (profileArg.description.match(/[a-z][a-z-]+/g) ?? []).filter(
+      (w: string) => w.includes('-') || w.length > 3
+    );
+    const real = PROFILES.map((p) => p.name);
+    const missing = real.filter((n) => !profileArg.description.includes(n));
+    expect(missing, 'profiles missing from the server.json description').toEqual([]);
+    // And a renamed profile leaves its old name behind, which is worse than an
+    // omission because it reads as real.
+    const invented = described.filter(
+      (w) => /^(app|game|xcode|background)-/.test(w) && !real.includes(w)
+    );
+    expect(invented, 'server.json names a profile that does not exist').toEqual([]);
+  });
+
+  it('keeps the sub-profile example true', () => {
+    // "monetization:subscription-pricing is 24 tools instead of 206" is a claim
+    // about live data, and both halves drift.
+    const m = /monetization:([a-z-]+) is (\d+) tools instead of (\d+)/.exec(profileArg.description);
+    expect(m, 'the sub-profile example changed shape').toBeTruthy();
+    const [, subName, claimedNarrow, claimedWide] = m!;
+
+    const narrow = resolveSelection(`monetization:${subName}`)!;
+    const wide = resolveSelection('monetization')!;
+    // Same definition the guide's table and the setup picker use: the
+    // operations, the hand-written tools the selection carries, and core's.
+    const count = (sel: ReturnType<typeof resolveSelection>) =>
+      new Set([...operationsFor(sel), ...manualToolsFor(sel), ...CORE_MANUAL_TOOLS]).size;
+
+    expect(count(narrow), 'narrow count in server.json').toBe(Number(claimedNarrow));
+    expect(count(wide), 'wide count in server.json').toBe(Number(claimedWide));
   });
 });


### PR DESCRIPTION
Edited on the Turkish side first and mirrored into English, so the two halves stay the same document.

## README

- The **2.0.0 breaking-release callout is gone.** 2.0.0 is two releases back, and the notice was the first thing a new reader met.
- The setup recording's caption leads with what the wizard does rather than how it was recorded.
- `#### Profiles` moves above its GIF, and the picker caption goes — the image shows what the sentence was describing.
- "Local by design" loses the paragraph arguing why hosting a `.p8` is a bad idea and keeps the part that says what Heimdall does instead.

## CHANGELOG

The seven-paragraph `Documentation` section in the 2.1.0 entry becomes two bullets under `Fixed`.

What it recorded that nothing else does is the drift itself — 868/875/883 across four surfaces, `CITATION.cff` two releases behind — and the pre-flight that now fails a release on a mismatch. Both are kept, because [publish.yml](.github/workflows/publish.yml) cuts the release notes straight from this section, and a guard nobody knows about is a guard nobody keeps.

## Two things worth knowing about the result

The `[!NOTE]` and `[!IMPORTANT]` markers are gone but the blockquotes stay, so those blocks render as plain quotes rather than styled callouts.

The line about the setup GIF being recorded against a stand-in API with invented credentials now appears once — on the demo GIF at the top — rather than twice.