### PR TITLE
docs: name the Dockerfile's real consumers, and the two it does not have

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
-# Dockerfile — used only for automated introspection (Glama / MCP Registry checks).
-# It boots the MCP server so a harness can call tools/list. The ASC_* values below are
-# throwaway placeholders: the key is generated during the build, is NOT registered with
-# Apple and authorizes nothing — it only lets the server start for introspection (which
-# never calls Apple). Real users configure credentials via `npx -y @erayendes/asc-mcp
-# setup`; see README.
+# Dockerfile — used only for automated introspection: it boots the MCP server so a
+# directory or scanner can call tools/list. Nothing about installing Heimdall goes
+# through it; real users run `npx -y @erayendes/asc-mcp setup`, see README.
+#
+# Named consumers, because the header claimed two that do not read this file:
+#   Glama          builds from its own spec, not from here — debian:trixie-slim, pnpm,
+#                  mcp-proxy, cloning the repo at a pinned commit. Editing this file
+#                  changes nothing about a Glama build, and a Glama build failure is
+#                  not evidence of anything in it.
+#   MCP Registry   server.json declares one npm package and no Docker image, so the
+#                  registry installs from npm and never builds this either.
+# What is left is any directory that looks for a Dockerfile and boots it. That is worth
+# supporting and costs one file — but nobody specific is known to, so do not read a
+# green build here as a consumer being satisfied.
+#
+# The ASC_* values below are throwaway placeholders: the key is generated during the
+# build, is NOT registered with Apple and authorizes nothing — it only lets the server
+# start for introspection, which never calls Apple.
 #
 # Generated rather than pasted. The literal that used to sit here was inert, and it was
 # still a PEM in a public repository: every secret scanner flags one, and a reader has to

--- a/tests/dockerfile.test.ts
+++ b/tests/dockerfile.test.ts
@@ -1,6 +1,9 @@
 /**
- * The Dockerfile exists so directories and registries can boot the server and
- * call tools/list. What it passes on the command line is therefore the only
+ * The Dockerfile exists so a directory that boots servers through Docker can
+ * start this one and call tools/list — not Glama, which builds from its own
+ * spec, and not the MCP Registry, which installs the npm package; see the
+ * header of the Dockerfile itself. What it passes on the command line is
+ * therefore the only
  * configuration those scans ever see, which makes a stale profile name there a
  * silent failure rather than a loud one: a name that was removed does not crash,
  * it hits the tombstone and starts with a single tool explaining the split. An


### PR DESCRIPTION
The header said "used only for automated introspection (Glama / MCP Registry checks)". Neither of those reads this file.

**Glama builds from its own spec** — `debian:trixie-slim`, `pnpm`, `mcp-proxy`, cloning the repo at a pinned commit — which is visible in the Dockerfile it generates and prints on a failed build. Editing this file changes nothing about a Glama build, and a Glama build failure says nothing about its contents. That distinction cost a round of looking in the wrong place after a failure that turned out to be Glama's builder timing out while pulling its own base image.

**The MCP Registry does not build it either:** `server.json` declares one npm package and no Docker image, so the registry installs from npm.

What is left is any directory that looks for a Dockerfile and boots it. Worth supporting, cheap to keep — but nobody specific is known to, and the header now says so rather than implying that a green build here means a consumer was satisfied.

`tests/dockerfile.test.ts` carried the same claim in its own header and now points at the Dockerfile instead of repeating it.

Comments only — no build instruction changed.

**On the test run:** one local full-suite run reported 2 failures, and three runs since have been clean at 476 passing. I did not capture which two, so I cannot name them; the live `gate.test.ts` suite is the likely candidate. CI is the arbiter here.