### PR TITLE
fix: say what a relationship filter takes, and let the audit see it

### DIFF
--- a/scripts/ax-audit.ts
+++ b/scripts/ax-audit.ts
@@ -65,8 +65,15 @@ export interface AxDebt {
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   Boolean(v) && typeof v === 'object' && !Array.isArray(v);
 
-/** Apple's spec words relationship filters this way; they take opaque ids. */
-const ID_FILTER_HINT = /id\(s\) of related/i;
+/**
+ * Apple's spec words relationship filters this way and stops there. The clause
+ * has to be the END of the description for the parameter to count as unhinted:
+ * the generator appends its note rather than replacing the clause, so a rule
+ * that only looked for the clause counted every fixed parameter as still
+ * broken. That is how this axis sat at 84 through a fix that moved 20 of them —
+ * a ratchet that cannot see its own progress is not a ratchet.
+ */
+const ID_FILTER_HINT = /id\(s\) of related '[^']*'\s*$/i;
 
 function isWrite(op: Operation): boolean {
   return !op.readOnly;

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -189,12 +189,41 @@ const PARAM_NOTES: Array<[RegExp, string]> = [
     'Three-letter ISO-3166 alpha-3 code — USA, TUR, DEU, GBR. Not the two-letter form: ' +
       '"US" is accepted and silently returns an empty list.',
   ],
+  // 11 parameters, and the one an agent gets wrong most: everything else it
+  // knows an app by is the bundle ID, which matches nothing here.
+  [
+    /^filter\[app\]$/,
+    'The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches ' +
+      'nothing and comes back as 200 with an empty list.',
+  ],
 ];
+
+/**
+ * Apple words every relationship filter as "filter by id(s) of related 'x'" and
+ * stops there, which says what the parameter is called and nothing about what
+ * goes in it. They all fail the same silent way territory did: a plausible
+ * wrong value is not rejected, it answers 200 with an empty list, and an agent
+ * reads that as "there is none".
+ *
+ * So anything left on Apple's clause alone gets the shape of the answer and the
+ * trap, once, generated rather than hand-written per parameter — there are 64
+ * of them and Apple adds more with every spec.
+ */
+const RELATIONSHIP_FILTER = /id\(s\) of related '([^']+)'\s*$/i;
 
 function annotateParam(name: string, description: string): string {
   const note = PARAM_NOTES.find(([pattern]) => pattern.test(name))?.[1];
-  if (!note) return description;
-  return description ? `${description} ${note}` : note;
+  if (note) return description ? `${description} ${note}` : note;
+
+  const relationship = RELATIONSHIP_FILTER.exec(description ?? '')?.[1];
+  if (!relationship) return description;
+  return (
+    // `${relationship}` is Apple's own field name and is sometimes plural, so
+    // it is quoted rather than dropped into an article — no singularising.
+    `${description} Takes a '${relationship}' resource id, read from the call that lists ` +
+    `them — not a name. A value that matches nothing returns 200 with an empty list rather ` +
+    `than an error.`
+  );
 }
 
 

--- a/src/generated/operations.ts
+++ b/src/generated/operations.ts
@@ -1832,12 +1832,12 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[appStoreVersionLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersionLocalization'"
+        "description": "filter by id(s) of related 'appStoreVersionLocalization' Takes a 'appStoreVersionLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[appStoreVersionExperimentTreatmentLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersionExperimentTreatmentLocalization'"
+        "description": "filter by id(s) of related 'appStoreVersionExperimentTreatmentLocalization' Takes a 'appStoreVersionExperimentTreatmentLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[appPreviewSets]",
@@ -1925,12 +1925,12 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[appStoreVersionLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersionLocalization'"
+        "description": "filter by id(s) of related 'appStoreVersionLocalization' Takes a 'appStoreVersionLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[appStoreVersionExperimentTreatmentLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersionExperimentTreatmentLocalization'"
+        "description": "filter by id(s) of related 'appStoreVersionExperimentTreatmentLocalization' Takes a 'appStoreVersionExperimentTreatmentLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[appScreenshotSets]",
@@ -2551,12 +2551,12 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'"
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list."
       },
       {
         "name": "filter[builds]",
         "type": "array",
-        "description": "filter by id(s) of related 'builds'"
+        "description": "filter by id(s) of related 'builds' Takes a 'builds' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[appEncryptionDeclarations]",
@@ -4337,12 +4337,12 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[appStoreVersionLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersionLocalization'"
+        "description": "filter by id(s) of related 'appStoreVersionLocalization' Takes a 'appStoreVersionLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[appCustomProductPageLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appCustomProductPageLocalization'"
+        "description": "filter by id(s) of related 'appCustomProductPageLocalization' Takes a 'appCustomProductPageLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[appPreviewSets]",
@@ -4430,12 +4430,12 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[appStoreVersionLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersionLocalization'"
+        "description": "filter by id(s) of related 'appStoreVersionLocalization' Takes a 'appStoreVersionLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[appCustomProductPageLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appCustomProductPageLocalization'"
+        "description": "filter by id(s) of related 'appCustomProductPageLocalization' Takes a 'appCustomProductPageLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[appScreenshotSets]",
@@ -4962,12 +4962,12 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[appCustomProductPageLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appCustomProductPageLocalization'"
+        "description": "filter by id(s) of related 'appCustomProductPageLocalization' Takes a 'appCustomProductPageLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[appStoreVersionExperimentTreatmentLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersionExperimentTreatmentLocalization'"
+        "description": "filter by id(s) of related 'appStoreVersionExperimentTreatmentLocalization' Takes a 'appStoreVersionExperimentTreatmentLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[appPreviewSets]",
@@ -5055,12 +5055,12 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[appCustomProductPageLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appCustomProductPageLocalization'"
+        "description": "filter by id(s) of related 'appCustomProductPageLocalization' Takes a 'appCustomProductPageLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[appStoreVersionExperimentTreatmentLocalization]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersionExperimentTreatmentLocalization'"
+        "description": "filter by id(s) of related 'appStoreVersionExperimentTreatmentLocalization' Takes a 'appStoreVersionExperimentTreatmentLocalization' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[appScreenshotSets]",
@@ -6258,7 +6258,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[builds]",
         "type": "array",
-        "description": "filter by id(s) of related 'builds'"
+        "description": "filter by id(s) of related 'builds' Takes a 'builds' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[appEncryptionDeclarations]",
@@ -6922,17 +6922,17 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[build]",
         "type": "array",
-        "description": "filter by id(s) of related 'build'"
+        "description": "filter by id(s) of related 'build' Takes a 'build' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[build.preReleaseVersion]",
         "type": "array",
-        "description": "filter by id(s) of related 'build.preReleaseVersion'"
+        "description": "filter by id(s) of related 'build.preReleaseVersion' Takes a 'build.preReleaseVersion' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[tester]",
         "type": "array",
-        "description": "filter by id(s) of related 'tester'"
+        "description": "filter by id(s) of related 'tester' Takes a 'tester' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "sort",
@@ -7037,17 +7037,17 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[build]",
         "type": "array",
-        "description": "filter by id(s) of related 'build'"
+        "description": "filter by id(s) of related 'build' Takes a 'build' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[build.preReleaseVersion]",
         "type": "array",
-        "description": "filter by id(s) of related 'build.preReleaseVersion'"
+        "description": "filter by id(s) of related 'build.preReleaseVersion' Takes a 'build.preReleaseVersion' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[tester]",
         "type": "array",
-        "description": "filter by id(s) of related 'tester'"
+        "description": "filter by id(s) of related 'tester' Takes a 'tester' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "sort",
@@ -8052,7 +8052,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[appStoreVersions]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersions'"
+        "description": "filter by id(s) of related 'appStoreVersions' Takes a 'appStoreVersions' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[id]",
@@ -9212,7 +9212,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'"
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list."
       },
       {
         "name": "fields[betaAppLocalizations]",
@@ -9326,7 +9326,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'",
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list.",
         "required": true
       },
       {
@@ -9462,7 +9462,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[build]",
         "type": "array",
-        "description": "filter by id(s) of related 'build'",
+        "description": "filter by id(s) of related 'build' Takes a 'build' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error.",
         "required": true
       },
       {
@@ -9585,7 +9585,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[build]",
         "type": "array",
-        "description": "filter by id(s) of related 'build'"
+        "description": "filter by id(s) of related 'build' Takes a 'build' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[betaBuildLocalizations]",
@@ -10170,12 +10170,12 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'"
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list."
       },
       {
         "name": "filter[builds]",
         "type": "array",
-        "description": "filter by id(s) of related 'builds'"
+        "description": "filter by id(s) of related 'builds' Takes a 'builds' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[id]",
@@ -10335,7 +10335,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'"
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list."
       },
       {
         "name": "fields[betaLicenseAgreements]",
@@ -10851,17 +10851,17 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[apps]",
         "type": "array",
-        "description": "filter by id(s) of related 'apps'"
+        "description": "filter by id(s) of related 'apps' Takes a 'apps' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[betaGroups]",
         "type": "array",
-        "description": "filter by id(s) of related 'betaGroups'"
+        "description": "filter by id(s) of related 'betaGroups' Takes a 'betaGroups' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[builds]",
         "type": "array",
-        "description": "filter by id(s) of related 'builds'"
+        "description": "filter by id(s) of related 'builds' Takes a 'builds' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[id]",
@@ -11000,7 +11000,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[build]",
         "type": "array",
-        "description": "filter by id(s) of related 'build'"
+        "description": "filter by id(s) of related 'build' Takes a 'build' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[id]",
@@ -11781,22 +11781,22 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[preReleaseVersion]",
         "type": "array",
-        "description": "filter by id(s) of related 'preReleaseVersion'"
+        "description": "filter by id(s) of related 'preReleaseVersion' Takes a 'preReleaseVersion' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'"
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list."
       },
       {
         "name": "filter[betaGroups]",
         "type": "array",
-        "description": "filter by id(s) of related 'betaGroups'"
+        "description": "filter by id(s) of related 'betaGroups' Takes a 'betaGroups' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[appStoreVersion]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersion'"
+        "description": "filter by id(s) of related 'appStoreVersion' Takes a 'appStoreVersion' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[id]",
@@ -12718,22 +12718,22 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[preReleaseVersion]",
         "type": "array",
-        "description": "filter by id(s) of related 'preReleaseVersion'"
+        "description": "filter by id(s) of related 'preReleaseVersion' Takes a 'preReleaseVersion' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'"
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list."
       },
       {
         "name": "filter[betaGroups]",
         "type": "array",
-        "description": "filter by id(s) of related 'betaGroups'"
+        "description": "filter by id(s) of related 'betaGroups' Takes a 'betaGroups' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[appStoreVersion]",
         "type": "array",
-        "description": "filter by id(s) of related 'appStoreVersion'"
+        "description": "filter by id(s) of related 'appStoreVersion' Takes a 'appStoreVersion' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[id]",
@@ -13105,7 +13105,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[builds]",
         "type": "array",
-        "description": "filter by id(s) of related 'builds'"
+        "description": "filter by id(s) of related 'builds' Takes a 'builds' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "sort",
@@ -13215,7 +13215,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'"
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list."
       },
       {
         "name": "fields[ciProducts]",
@@ -13359,7 +13359,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[builds]",
         "type": "array",
-        "description": "filter by id(s) of related 'builds'"
+        "description": "filter by id(s) of related 'builds' Takes a 'builds' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "sort",
@@ -14923,7 +14923,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[gameCenterDetail]",
         "type": "array",
-        "description": "filter by id(s) of related 'gameCenterDetail'"
+        "description": "filter by id(s) of related 'gameCenterDetail' Takes a 'gameCenterDetail' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "limit",
@@ -16212,7 +16212,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[gameCenterAchievement]",
         "type": "array",
-        "description": "filter by id(s) of related 'gameCenterAchievement'"
+        "description": "filter by id(s) of related 'gameCenterAchievement' Takes a 'gameCenterAchievement' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "limit",
@@ -17104,7 +17104,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[gameCenterLeaderboard]",
         "type": "array",
-        "description": "filter by id(s) of related 'gameCenterLeaderboard'"
+        "description": "filter by id(s) of related 'gameCenterLeaderboard' Takes a 'gameCenterLeaderboard' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "limit",
@@ -17143,7 +17143,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[gameCenterLeaderboardSet]",
         "type": "array",
-        "description": "filter by id(s) of related 'gameCenterLeaderboardSet'"
+        "description": "filter by id(s) of related 'gameCenterLeaderboardSet' Takes a 'gameCenterLeaderboardSet' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "limit",
@@ -17289,7 +17289,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'"
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list."
       },
       {
         "name": "filter[id]",
@@ -18082,7 +18082,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[gameCenterDetails]",
         "type": "array",
-        "description": "filter by id(s) of related 'gameCenterDetails'"
+        "description": "filter by id(s) of related 'gameCenterDetails' Takes a 'gameCenterDetails' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "fields[gameCenterGroups]",
@@ -19062,13 +19062,13 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[gameCenterLeaderboardSet]",
         "type": "array",
-        "description": "filter by id(s) of related 'gameCenterLeaderboardSet'",
+        "description": "filter by id(s) of related 'gameCenterLeaderboardSet' Takes a 'gameCenterLeaderboardSet' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error.",
         "required": true
       },
       {
         "name": "filter[gameCenterLeaderboard]",
         "type": "array",
-        "description": "filter by id(s) of related 'gameCenterLeaderboard'",
+        "description": "filter by id(s) of related 'gameCenterLeaderboard' Takes a 'gameCenterLeaderboard' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error.",
         "required": true
       },
       {
@@ -19782,7 +19782,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[gameCenterDetail]",
         "type": "array",
-        "description": "filter by id(s) of related 'gameCenterDetail'"
+        "description": "filter by id(s) of related 'gameCenterDetail' Takes a 'gameCenterDetail' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "limit",
@@ -20269,7 +20269,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[gameCenterDetail]",
         "type": "array",
-        "description": "filter by id(s) of related 'gameCenterDetail'"
+        "description": "filter by id(s) of related 'gameCenterDetail' Takes a 'gameCenterDetail' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "limit",
@@ -22018,7 +22018,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[inAppPurchaseV2]",
         "type": "array",
-        "description": "filter by id(s) of related 'inAppPurchaseV2'"
+        "description": "filter by id(s) of related 'inAppPurchaseV2' Takes a 'inAppPurchaseV2' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "limit",
@@ -23208,7 +23208,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[relatedApps]",
         "type": "array",
-        "description": "filter by id(s) of related 'relatedApps'"
+        "description": "filter by id(s) of related 'relatedApps' Takes a 'relatedApps' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "sort",
@@ -23695,12 +23695,12 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'"
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list."
       },
       {
         "name": "filter[builds]",
         "type": "array",
-        "description": "filter by id(s) of related 'builds'"
+        "description": "filter by id(s) of related 'builds' Takes a 'builds' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "sort",
@@ -24257,7 +24257,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[app]",
         "type": "array",
-        "description": "filter by id(s) of related 'app'",
+        "description": "filter by id(s) of related 'app' The numeric Apple ID from apps__list, not the bundle ID. A bundle ID matches nothing and comes back as 200 with an empty list.",
         "required": true
       },
       {
@@ -26343,7 +26343,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[subscription]",
         "type": "array",
-        "description": "filter by id(s) of related 'subscription'"
+        "description": "filter by id(s) of related 'subscription' Takes a 'subscription' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[upfrontPricePointId]",
@@ -26391,7 +26391,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[subscription]",
         "type": "array",
-        "description": "filter by id(s) of related 'subscription'"
+        "description": "filter by id(s) of related 'subscription' Takes a 'subscription' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[upfrontPricePointId]",
@@ -27056,7 +27056,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[subscriptionPricePoint]",
         "type": "array",
-        "description": "filter by id(s) of related 'subscriptionPricePoint'"
+        "description": "filter by id(s) of related 'subscriptionPricePoint' Takes a 'subscriptionPricePoint' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "filter[territory]",
@@ -27476,7 +27476,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[visibleApps]",
         "type": "array",
-        "description": "filter by id(s) of related 'visibleApps'"
+        "description": "filter by id(s) of related 'visibleApps' Takes a 'visibleApps' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "sort",
@@ -27630,7 +27630,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "filter[visibleApps]",
         "type": "array",
-        "description": "filter by id(s) of related 'visibleApps'"
+        "description": "filter by id(s) of related 'visibleApps' Takes a 'visibleApps' resource id, read from the call that lists them — not a name. A value that matches nothing returns 200 with an empty list rather than an error."
       },
       {
         "name": "sort",

--- a/tests/ax-audit.test.ts
+++ b/tests/ax-audit.test.ts
@@ -24,8 +24,15 @@ import type { Operation } from '../src/core/types.js';
 const CEILING = {
   /** AXIS1 — findability: descriptions still in Apple's words, not a user's. */
   boilerplate: 712,
-  /** AXIS2 — silent empty results: id-valued filters with no format hint. */
-  unhintedIdFilters: 77,
+  /**
+   * AXIS2 — silent empty results: id-valued filters with no format hint.
+   *
+   * Zero, and it can stay zero: the generator hints anything still ending on
+   * Apple's "id(s) of related 'x'" clause, so a new spec's parameters inherit
+   * the note. A number above zero here means Apple worded one a new way and it
+   * fell through the rule — which is exactly when someone should look.
+   */
+  unhintedIdFilters: 0,
   /** AXIS3 — opaque confirmations: reference types a preview cannot humanise. */
   unresolvedRefTypes: 179,
   /** AXIS4 — path length: writes that need a lookup call first. */


### PR DESCRIPTION
Closes MIL-220. Two halves of one bug.

## The measurement was blind to its own fix

`ID_FILTER_HINT` matched Apple's `id(s) of related 'x'` clause anywhere in the description, but the generator **appends** its note rather than replacing the clause. So the 20 territory parameters fixed in AI-204 kept matching, and AXIS2 read **84 before and after**. A ratchet that cannot see progress is not a ratchet.

The clause now has to be at the *end* of the description to count as unhinted.

## The other 64 said nothing about what value they take

Every one fails the way territory did: a plausible wrong value is not rejected, it answers `200` with an empty list, and an agent reads that as "there is none".

- **`filter[app]` gets its own note** — 11 parameters, and the one an agent gets wrong most, because everything else it knows an app by is the bundle ID, which matches nothing here.
- **The rest are hinted from the clause itself**, generated rather than hand-written per parameter. Apple adds more of these with every spec and a lookup table would go stale on the next one.

```
filter[app]     … The numeric Apple ID from apps__list, not the bundle ID. A bundle ID
                  matches nothing and comes back as 200 with an empty list.
filter[builds]  … Takes a 'builds' resource id, read from the call that lists them — not
                  a name. A value that matches nothing returns 200 with an empty list
                  rather than an error.
```

## Result

`AXIS2 silent empty results  0 id-valued filter params with no format hint` — down from 84, and the ceiling drops to 0 with it. A number above zero now means Apple worded one a new way and it fell through the rule, which is exactly when someone should look.

498 tests passing.