### PR TITLE
feat: name a reference in the confirmation prompt without a resolver per type

### DIFF
--- a/scripts/ax-audit.ts
+++ b/scripts/ax-audit.ts
@@ -22,7 +22,7 @@
  */
 import { OPERATIONS } from '../src/generated/operations.js';
 import { BODY_SCHEMAS } from '../src/generated/body-schemas.js';
-import { REF_RESOLVERS } from '../src/core/confirm.js';
+import { REF_RESOLVERS, SELF_DESCRIBING, GET_BY_ID } from '../src/core/confirm.js';
 import { CURATED } from './describe.js';
 import type { Operation } from '../src/core/types.js';
 
@@ -54,7 +54,7 @@ export interface AxDebt {
   boilerplate: OpFinding[];
   /** AXIS2 — id-valued filter params with neither an enum nor a format hint. */
   unhintedIdFilters: OpFinding[];
-  /** AXIS3 — reference types appearing in write bodies with no REF_RESOLVERS entry. */
+  /** AXIS3 — reference types a confirmation prompt can only show as a raw id. */
   unresolvedRefTypes: TypeFinding[];
   /** AXIS4 — writes that cannot be called without first fetching an id. */
   writesNeedingLookup: OpFinding[];
@@ -137,7 +137,11 @@ export function auditAx(operations: readonly Operation[] = LOADABLE): AxDebt {
   }
 
   // AXIS3 — every type here shows up in a confirmation prompt as a raw id
-  // unless REF_RESOLVERS knows how to name it.
+  // because nothing can name it: no hand-written resolver, no readable id of
+  // its own, and no GET-by-id endpoint for the generic resolver to call. The
+  // count used to be "types without a hand-written resolver", which made the
+  // axis a to-do list 175 entries long instead of a measure of what a user
+  // cannot read.
   const typeUses = new Map<string, number>();
   for (const op of writes) {
     const schema = op.bodyRef ? BODY_SCHEMAS[op.bodyRef] : undefined;
@@ -147,7 +151,7 @@ export function auditAx(operations: readonly Operation[] = LOADABLE): AxDebt {
     for (const t of types) typeUses.set(t, (typeUses.get(t) ?? 0) + 1);
   }
   const unresolvedRefTypes: TypeFinding[] = [...typeUses.entries()]
-    .filter(([type]) => !REF_RESOLVERS[type])
+    .filter(([type]) => !REF_RESOLVERS[type] && !SELF_DESCRIBING.has(type) && !GET_BY_ID.has(type))
     .map(([type, uses]) => ({ type, uses }))
     .sort((a, b) => b.uses - a.uses || a.type.localeCompare(b.type));
 

--- a/src/core/confirm.ts
+++ b/src/core/confirm.ts
@@ -2,28 +2,29 @@
  * Write confirmation guard.
  *
  * Mutating tools (anything not marked readOnlyHint) can change real App Store
- * Connect data — prices, submissions, deletions. With --confirm, we ask the
- * user before running one, so a vague or misread instruction ("set the price to
- * 0.99") can't execute unchecked. The prompt carries an impact preview
- * (operation, target, changed fields, risk level, reversibility), and
+ * Connect data — prices, submissions, deletions. Before a revenue, destructive,
+ * infrastructure or access one runs, we ask the user, so a vague or misread
+ * instruction ("set the price to 0.99") can't execute unchecked. The prompt
+ * carries an impact preview (operation, target, changed fields, risk level,
+ * reversibility), and
  * high-stakes levels (revenue/destructive/infrastructure/access) require the
  * user to TYPE the confirmation instead of ticking a box.
  *
- * Opt-in, not default. The gate is the client's job — every MCP client asks
- * before it runs a tool — and this guard can only run where the client renders
- * an elicitation form. On the ones that don't, it fired anyway and turned a
- * working write into "the user declined", which is the one thing the protocol
- * gives us no way to tell apart from a real refusal: a client that can't show
- * the form answers `decline` exactly like a user who clicked no. So the choice
- * is per-client and belongs to whoever configures it. What stays ours either
- * way is the preview — only this server knows that a flag spelled
- * `preserveCurrentPrice: false` moves existing subscribers to a new price.
+ * On by default for those four levels only, and that split was paid for twice.
+ * Asking on every write fired constantly, and a client that declares
+ * elicitation support but can't render the form answers `decline` — the one
+ * thing the protocol gives us no way to tell apart from a real refusal — so
+ * ordinary writes came back as "you refused". Asking on none removed the guard
+ * from the writes that move money. `--confirm` restores every write,
+ * `--no-confirm` removes it entirely.
  *
- * Turned on with --confirm / ASC_CONFIRM_WRITES=1. A client that never declared
- * elicitation can't be asked at all, so there the guard fails closed rather
- * than pretending to be on.
+ * What is ours either way is the preview: only this server knows that a flag
+ * spelled `preserveCurrentPrice: false` moves existing subscribers to a new
+ * price. A client that never declared elicitation can't be asked at all, so
+ * there the guard fails closed rather than pretending to be on.
  */
 import { STRONG_CONFIRM_LEVELS, REVERSIBILITY, type RiskLevel } from './risk.js';
+import { OPERATIONS } from '../generated/operations.js';
 
 /** The slice of the MCP Server we need — kept tiny so the logic is unit-testable. */
 export interface WriteConfirmer {
@@ -114,6 +115,76 @@ export const REF_RESOLVERS: Record<string, RefResolver> = {
   },
 };
 
+/**
+ * Types whose id is already the human-readable thing. A territory's id is its
+ * alpha-3 code — resolving `USA` to "USA" is a round trip to learn nothing.
+ */
+export const SELF_DESCRIBING = new Set(['territories']);
+
+/**
+ * type -> the GET-by-id path Apple gives it, read off the spec rather than
+ * assumed: 156 of the types that appear in write bodies have one, and a
+ * handful sit under /v2.
+ */
+export const GET_BY_ID: ReadonlyMap<string, string> = (() => {
+  const map = new Map<string, string>();
+  for (const op of OPERATIONS) {
+    const m = /^\/(v\d+)\/([A-Za-z0-9]+)\/\{id\}$/.exec(op.path);
+    if (op.method === 'GET' && m && !map.has(m[2])) map.set(m[2], `/${m[1]}/${m[2]}`);
+  }
+  return map;
+})();
+
+/**
+ * The attributes Apple uses to name a thing, best first. A resource carries at
+ * most a couple of these, so the first hit is the label.
+ */
+const LABEL_ATTRIBUTES = [
+  'name',
+  'referenceName',
+  'title',
+  'versionString',
+  'productId',
+  'bundleId',
+  'fileName',
+  'nickname',
+  'locale',
+  'email',
+  'deviceClass',
+  'platform',
+];
+
+/**
+ * Whatever a hand-written resolver does not cover.
+ *
+ * There are 179 reference types and four resolvers. Writing 175 more was never
+ * going to happen, and each would go stale with the spec; this covers the same
+ * ground with one call and no per-type maintenance. A hand-written resolver
+ * still wins where the good label is not a single attribute — a price point
+ * reads as "99.99 TRY (TUR)", which no generic rule would assemble.
+ */
+async function resolveGeneric(
+  http: RefReader,
+  type: string,
+  id: string
+): Promise<string | undefined> {
+  const base = GET_BY_ID.get(type);
+  if (!base) return undefined;
+  const res: any = await http.get(`${base}/${encodeURIComponent(id)}`);
+  const attributes = res?.data?.attributes;
+  if (!attributes) return undefined;
+  for (const key of LABEL_ATTRIBUTES) {
+    const value = attributes[key];
+    if (typeof value === 'string' && value) return value;
+  }
+  return undefined;
+}
+
+/** True when the preview can put a name, or the id itself, in front of a user. */
+function resolvable(type: string): boolean {
+  return Boolean(REF_RESOLVERS[type]) || SELF_DESCRIBING.has(type) || GET_BY_ID.has(type);
+}
+
 /** Collects every {type,id} reference in a JSON:API body. */
 function collectRefs(node: unknown, refs: Array<{ type: string; id: string }>): void {
   if (!node || typeof node !== 'object') return;
@@ -122,7 +193,7 @@ function collectRefs(node: unknown, refs: Array<{ type: string; id: string }>): 
     return;
   }
   const rec = node as Record<string, unknown>;
-  if (typeof rec.type === 'string' && typeof rec.id === 'string' && REF_RESOLVERS[rec.type]) {
+  if (typeof rec.type === 'string' && typeof rec.id === 'string' && resolvable(rec.type)) {
     refs.push({ type: rec.type, id: rec.id });
   }
   for (const v of Object.values(rec)) collectRefs(v, refs);
@@ -150,10 +221,15 @@ export async function resolveBodyRefs(
   });
 
   const labels = new Map<string, string>();
+  // A self-describing id needs no call, so it does not spend one of the four.
+  const needLookup = unique.filter((r) => !SELF_DESCRIBING.has(r.type));
+
   await Promise.all(
-    unique.slice(0, MAX_REF_LOOKUPS).map(async ({ type, id }) => {
+    needLookup.slice(0, MAX_REF_LOOKUPS).map(async ({ type, id }) => {
       try {
-        const label = await REF_RESOLVERS[type](http, id);
+        const label = REF_RESOLVERS[type]
+          ? await REF_RESOLVERS[type](http, id)
+          : await resolveGeneric(http, type, id);
         if (label) labels.set(`${type}/${id}`, label);
       } catch {
         // Best-effort display only — the raw id stays in the preview.

--- a/tests/ax-audit.test.ts
+++ b/tests/ax-audit.test.ts
@@ -33,8 +33,15 @@ const CEILING = {
    * fell through the rule — which is exactly when someone should look.
    */
   unhintedIdFilters: 0,
-  /** AXIS3 — opaque confirmations: reference types a preview cannot humanise. */
-  unresolvedRefTypes: 179,
+  /**
+   * AXIS3 — opaque confirmations: reference types a preview cannot humanise.
+   *
+   * 52, down from 179 when the count meant "types without a hand-written
+   * resolver". What is left are types Apple gives no GET-by-id endpoint, so
+   * there is nothing to fetch a name from — a resolver cannot be written for
+   * them, only a different write body could avoid them.
+   */
+  unresolvedRefTypes: 52,
   /** AXIS4 — path length: writes that need a lookup call first. */
   writesNeedingLookup: 256,
   /** AXIS4 — lists with no `filter[*]`, so an oversized response cannot be narrowed. */

--- a/tests/risk.test.ts
+++ b/tests/risk.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { riskFor, STRONG_CONFIRM_LEVELS } from '../src/core/risk.js';
 import { OPERATIONS } from '../src/generated/operations.js';
-import { buildWritePreview, confirmWrite, type WriteConfirmer } from '../src/core/confirm.js';
+import {
+  buildWritePreview,
+  confirmWrite,
+  resolveBodyRefs,
+  type WriteConfirmer,
+} from '../src/core/confirm.js';
 import { ToolRegistry, toMcpTool } from '../src/core/registry.js';
 import { AscHttpClient } from '../src/core/http.js';
 import { TokenProvider } from '../src/core/jwt.js';
@@ -72,6 +77,51 @@ describe('risk manifest', () => {
       if (op.readOnly) expect(op.risk, op.name).toBeUndefined();
       else expect(op.risk, op.name).toBeTruthy();
     }
+  });
+});
+
+describe('reference resolution in a preview', () => {
+  /** Records what was fetched so "no call at all" is testable, not assumed. */
+  const reader = (attributes: Record<string, unknown>) => {
+    const paths: string[] = [];
+    return {
+      paths,
+      get: async (path: string) => {
+        paths.push(path);
+        return { data: { attributes } };
+      },
+    };
+  };
+
+  // The whole point of the generic resolver: a type nobody wrote a resolver for
+  // still reaches the user as a name. betaTesters has no entry in REF_RESOLVERS
+  // and does have a GET-by-id, which is the shape 152 other types share.
+  it('names a type that has no hand-written resolver', async () => {
+    const http = reader({ firstName: 'Ada', email: 'ada@example.com' });
+    const labels = await resolveBodyRefs(http, {
+      relationships: { betaTester: { data: { type: 'betaTesters', id: 'abc' } } },
+    });
+    expect(http.paths).toEqual(['/v1/betaTesters/abc']);
+    expect(labels.get('betaTesters/abc')).toBe('ada@example.com');
+  });
+
+  // A territory id is already its alpha-3 code. Fetching it would spend one of
+  // the four lookups to learn nothing, and the four are the latency budget.
+  it('spends no call on an id that is already readable', async () => {
+    const http = reader({ currency: 'TRY' });
+    await resolveBodyRefs(http, {
+      relationships: { territory: { data: { type: 'territories', id: 'TUR' } } },
+    });
+    expect(http.paths).toEqual([]);
+  });
+
+  it('leaves a type with no GET-by-id endpoint alone', async () => {
+    const http = reader({ name: 'never fetched' });
+    const labels = await resolveBodyRefs(http, {
+      relationships: { x: { data: { type: 'notAResourceType', id: 'zzz' } } },
+    });
+    expect(http.paths).toEqual([]);
+    expect(labels.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
Closes MIL-207.

179 reference types appear in write bodies and four had a resolver, so a confirmation prompt showed the other 175 as raw ids — someone approving a change they cannot read. Writing 175 resolvers was never going to happen, and each would go stale with the next spec.

## One generic resolver

GET the type's by-id endpoint, take the first attribute Apple uses to name a thing (`name`, `referenceName`, `title`, `versionString`, `productId`, …). The path is read **off the spec** rather than assumed — 156 of those types have one and a few sit under `/v2`.

Hand-written resolvers still win where the good label is not a single attribute: a price point reads `99.99 TRY (TUR)`, which no generic rule would assemble.

**Territories are skipped, not resolved.** The id *is* the alpha-3 code, so a lookup would spend one of the four the latency budget allows to learn nothing.

## The audit was measuring the wrong thing

`unresolvedRefTypes` counted "types without a hand-written resolver", which made AXIS3 a to-do list 175 entries long rather than a measure of what a user cannot read. It now counts types with no resolver, no readable id **and** no by-id endpoint to fetch a name from.

```
AXIS3 opaque confirmations  52 reference types unresolved   (was 179)
```

The remaining 52 are types Apple gives no GET-by-id at all — for those the fix is a different write body, not a resolver.

## Verification

Three tests on a recording reader, so "no call at all" is asserted rather than assumed: a type with no hand-written resolver is named, a territory costs zero calls, and a type with no by-id endpoint is left alone. 501 passing.

Also refreshes the header of `confirm.ts`, which still described the gate as opt-in after #55 moved the default.