### PR TITLE
feat: answer a failed call with fields instead of a sentence

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. The format is based on 
 ## English
 ### [Unreleased]
 
+#### A failed call answers with fields, not a sentence
+An Apple rejection used to come back as three lines of prose, which meant an agent deciding what to do next had to parse English to learn whether trying again could work. It now returns JSON: `status`, `retryable`, `appleRequestId`, `suggestedAction`, and `issues[]` carrying Apple's own `code`, `title`, `detail` and — new — `source`, which names the field or parameter that was rejected. `source` was being dropped from the type before it could reach anyone, though Apple has been sending it all along.
+
+Our own refusals stay prose. A wrong profile or a read-only block answers with hand-written multi-line guidance — the register command, the sub-profile to load — and JSON would turn that into a wall of escapes. Only a real HTTP failure gets the structured shape.
+
+
 #### Confirmation is back on, for the writes that are hard to undo
 The gate now defaults to the four levels the risk manifest calls `revenue`, `destructive`, `infrastructure` and `access` — changing a price, handing out Admin, deleting a certificate, pulling an app from sale. Everything below them runs on the client's own per-call tool approval, which is the gate that always exists.
 
@@ -225,6 +231,12 @@ Safety and usability release: every write is now schema-checked locally, preview
 
 ## Türkçe
 ### [Unreleased]
+
+#### Başarısız bir çağrı cümle değil, alan döndürüyor
+Apple'ın reddi eskiden üç satır düz metin olarak dönüyordu; yani sonraki adıma karar veren bir ajanın, tekrar denemenin işe yarayıp yaramayacağını öğrenmek için İngilizce ayrıştırması gerekiyordu. Artık JSON dönüyor: `status`, `retryable`, `appleRequestId`, `suggestedAction` ve Apple'ın kendi `code`, `title`, `detail` alanlarını taşıyan `issues[]` — bir de yeni olarak `source`, reddedilen alanı ya da parametreyi adıyla veriyor. `source` tipten düşüyordu ve kimseye ulaşmıyordu, oysa Apple baştan beri gönderiyormuş.
+
+Kendi retlerimiz düz metin kalıyor. Yanlış profil ya da salt-okunur engeli, elle yazılmış çok satırlı yönlendirme döndürüyor — register komutu, yüklenecek alt profil — ve JSON bunu kaçış karakterleri duvarına çevirirdi. Yalnızca gerçek bir HTTP hatası yapılandırılmış biçimi alıyor.
+
 
 #### Onay geri açıldı — geri alması zor yazmalar için
 Kapı artık risk manifestindeki dört seviyede varsayılan olarak açık: `revenue`, `destructive`, `infrastructure`, `access` — fiyat değiştirme, Admin yetkisi verme, sertifika silme, uygulamayı satıştan kaldırma. Bunların altındaki her şey client'ın kendi çağrı-başı araç onayıyla çalışıyor; her zaman var olan kapı da odur.

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,9 +1,25 @@
+/**
+ * One entry from Apple's `errors[]`. `source` is the half that says *where*:
+ * a `pointer` into the request body ("/data/attributes/versionString") or the
+ * `parameter` that was wrong. It was being dropped from the type — and so from
+ * everything downstream — while sitting right there in the payload.
+ */
+export interface AscApiErrorDetail {
+  code?: string;
+  title?: string;
+  detail?: string;
+  source?: { pointer?: string; parameter?: string };
+}
+
+/** Statuses the HTTP layer will retry; anything else is the caller's to fix. */
+const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
 /** Structured error carrying whatever detail Apple returned. */
 export class AscApiError extends Error {
   constructor(
     message: string,
     readonly status: number,
-    readonly errors: Array<{ code?: string; title?: string; detail?: string }> = [],
+    readonly errors: AscApiErrorDetail[] = [],
     readonly requestId?: string
   ) {
     super(message);
@@ -16,6 +32,14 @@ export class AscApiError extends Error {
     return this.errors
       .map((e) => [e.title, e.detail].filter(Boolean).join(': '))
       .join(' | ');
+  }
+
+  /**
+   * Whether trying again could work. Status 0 is a network or client-side
+   * failure that never reached Apple, which is the most retryable case of all.
+   */
+  get retryable(): boolean {
+    return this.status === 0 || RETRYABLE_STATUSES.has(this.status);
   }
 }
 

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -12,7 +12,7 @@
  */
 import { TokenProvider } from './jwt.js';
 import { RateLimiter, type RateLimitOptions } from './rate-limit.js';
-import { AscApiError } from './errors.js';
+import { AscApiError, type AscApiErrorDetail } from './errors.js';
 
 export const ASC_HOST = 'api.appstoreconnect.apple.com';
 export const ASC_BASE_URL = `https://${ASC_HOST}`;
@@ -397,7 +397,7 @@ export function backoffMs(attempt: number, retryAfter: string | null): number {
  * Actionable hints for the Apple errors people actually hit, appended to the
  * error message so the fix travels with the failure (mirrors SUPPORT.md).
  */
-const STATUS_HINTS: Record<number, string> = {
+export const STATUS_HINTS: Record<number, string> = {
   401: 'Check that ASC_KEY_ID, ASC_ISSUER_ID and the .p8 key match and are not revoked.',
   403:
     "The API key's role lacks permission for this operation: sales/finance reports need " +
@@ -406,15 +406,15 @@ const STATUS_HINTS: Record<number, string> = {
   409:
     'App Store Connect rejected the change for the current resource state — a version in ' +
     'review or already released is locked, and many fields are only editable in specific ' +
-    "states. Fetch the resource first to see its state; the error details above name the " +
-    'field when Apple provides it.',
+    "states. Fetch the resource first to see its state; the issues[] entries name the " +
+    'field when Apple provides one.',
   429:
     "Apple's rate limit was hit even though requests are paced locally — something else " +
     'may be sharing this API key.',
 };
 
 async function toApiError(res: Response): Promise<AscApiError> {
-  let errors: Array<{ code?: string; title?: string; detail?: string }> = [];
+  let errors: AscApiErrorDetail[] = [];
   let message = `App Store Connect API returned ${res.status}`;
 
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { TokenProvider } from './core/jwt.js';
-import { AscHttpClient } from './core/http.js';
+import { AscHttpClient, STATUS_HINTS } from './core/http.js';
 import {
   ToolRegistry,
   DEFAULT_DOMAINS,
@@ -724,14 +724,44 @@ export function createRemovedProfileServer(name: string): Server {
   return server;
 }
 
-function formatError(err: unknown, toolName: string): string {
-  if (err instanceof AscApiError) {
-    const lines = [`${toolName} failed: ${err.summary}`];
-    if (err.status) lines.push(`HTTP status: ${err.status}`);
-    if (err.requestId) lines.push(`Apple request ID: ${err.requestId}`);
-    return lines.join('\n');
+/**
+ * A failure the caller can act on without reading prose.
+ *
+ * Not `structuredContent`: MCP defines that field as the result matching the
+ * tool's `outputSchema`, and five tools declare one — an error object there
+ * would fail a validating client on a response that is correctly an error.
+ * A JSON text block is what every successful generated call already returns,
+ * so this is the same shape rather than a second convention.
+ *
+ * `summary` leads because a human reads the first line. Everything under it is
+ * for the caller deciding what to do next: `retryable` says whether trying
+ * again could work at all, `issues[].source` names the field or parameter
+ * Apple rejected, and `suggestedAction` carries the status hint that used to be
+ * glued onto the end of the message.
+ */
+export function formatError(err: unknown, toolName: string): string {
+  // Status 0 is ours, not Apple's: a validation refusal, a wrong profile, a
+  // read-only block. Those messages are hand-written multi-line guidance —
+  // register commands, sub-profile names — and JSON would turn them into a
+  // wall of \n escapes. Only a real HTTP failure gets the structured shape.
+  if (!(err instanceof AscApiError) || !err.status) {
+    return `${toolName} failed: ${err instanceof AscApiError ? err.summary : (err as Error).message}`;
   }
-  return `${toolName} failed: ${(err as Error).message}`;
+  return JSON.stringify(
+    {
+      error: {
+        summary: `${toolName} failed: ${err.summary}`,
+        operation: toolName,
+        status: err.status || undefined,
+        retryable: err.retryable,
+        appleRequestId: err.requestId,
+        suggestedAction: STATUS_HINTS[err.status],
+        issues: err.errors.length ? err.errors : undefined,
+      },
+    },
+    null,
+    2
+  );
 }
 
 export { SPEC_VERSION };

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -15,7 +15,8 @@
 import { describe, it, expect } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createServer } from '../src/server.js';
+import { createServer, formatError } from '../src/server.js';
+import { AscApiError } from '../src/core/errors.js';
 import { resolveSelection } from '../src/profiles.js';
 import type { ServerConfig } from '../src/core/config.js';
 
@@ -112,5 +113,52 @@ describe('the client-independent path', () => {
     expect(res.isError).toBe(true); // missing required id
     const names = (await client.listTools()).tools.map((t) => t.name);
     expect(names).toContain('apps__app_price_schedule__get');
+  });
+});
+
+/**
+ * The half of MIL-192 that was still prose. An agent deciding what to do after
+ * a failure needs three things the old text buried: whether trying again could
+ * work at all, which field Apple rejected, and what to do about the status.
+ * `source` in particular was dropped from the type before it could reach here.
+ */
+describe('what a failure tells the caller', () => {
+  it('turns an Apple rejection into fields, not a sentence', () => {
+    const err = new AscApiError(
+      'App Store Connect API returned 409',
+      409,
+      [
+        {
+          code: 'ENTITY_ERROR',
+          title: 'An attribute value is invalid',
+          detail: 'versionString must be higher than the released version',
+          source: { pointer: '/data/attributes/versionString' },
+        },
+      ],
+      'REQ-123'
+    );
+    const parsed = JSON.parse(formatError(err, 'app_store_versions__create')).error;
+
+    expect(parsed.status).toBe(409);
+    expect(parsed.retryable).toBe(false);
+    expect(parsed.appleRequestId).toBe('REQ-123');
+    expect(parsed.issues[0].source.pointer).toBe('/data/attributes/versionString');
+    // The status hint used to be glued onto the end of the message.
+    expect(parsed.suggestedAction).toMatch(/in review or already released/);
+  });
+
+  it('marks a rate limit as worth retrying and a bad request as not', () => {
+    const retryable = (status: number) =>
+      JSON.parse(formatError(new AscApiError('x', status), 'apps__list')).error.retryable;
+    expect(retryable(429)).toBe(true);
+    expect(retryable(503)).toBe(true);
+    expect(retryable(400)).toBe(false);
+  });
+
+  // Our own refusals carry hand-written multi-line guidance — register
+  // commands, sub-profile names. JSON would turn those into \n escapes.
+  it('leaves a local refusal as the prose it was written as', () => {
+    const text = formatError(new AscApiError('Loaded read-only. Use asc__load.', 0), 'asc__call');
+    expect(text).toBe('asc__call failed: Loaded read-only. Use asc__load.');
   });
 });


### PR DESCRIPTION
The remaining half of MIL-192. Structured output shipped in 2.1.0; structured errors did not, so a failure was still three lines of prose — and an agent deciding what to do next had to parse English to learn whether retrying could work.

## What an Apple rejection returns now

```json
{
  "error": {
    "summary": "app_store_versions__create failed: An attribute value is invalid: versionString must be higher",
    "operation": "app_store_versions__create",
    "status": 409,
    "retryable": false,
    "appleRequestId": "REQ-1",
    "suggestedAction": "App Store Connect rejected the change for the current resource state …",
    "issues": [
      {
        "code": "ENTITY_ERROR",
        "title": "An attribute value is invalid",
        "detail": "versionString must be higher",
        "source": { "pointer": "/data/attributes/versionString" }
      }
    ]
  }
}
```

`source` is the one that was missing entirely. It names the field or parameter Apple rejected, and Apple has been sending it all along — `AscApiError`'s type dropped it on the way in.

## Two decisions worth stating

**Not `structuredContent`.** MCP defines that field as the result matching the tool's `outputSchema`, and five tools declare one, so an error object there would fail a validating client on a response that is correctly an error. A JSON text block is what every successful generated call already returns.

**Our own refusals stay prose.** A wrong profile or a read-only block answers with hand-written multi-line guidance — the register command, the sub-profile to load — and JSON would turn those into a wall of `\n` escapes. Status `0` is the split: it means the request never reached Apple.

`retryable` is derived from the same status set the HTTP layer retries on, so the two cannot disagree, plus status 0.

504 tests passing; three new ones cover the shape, the retryable split and the prose path.