### PR TITLE
test: drop two search queries from the failing budget that already pass

### DIFF
--- a/tests/search-intents.test.ts
+++ b/tests/search-intents.test.ts
@@ -81,7 +81,7 @@ const PASSING = EVALUATION.filter((e) => e.pass);
 const FAILING = EVALUATION.filter((e) => !e.pass);
 
 /**
- * Pinned list of known failing queries: 118 that find nothing, 64 that rank
+ * Pinned list of known failing queries: 116 that find nothing, 66 that rank
  * below third. A failure not on this list breaks CI, so the cost of a change
  * has to be written down before it can land.
  *
@@ -203,10 +203,8 @@ const KNOWN_FAILING_QUERIES: string[] = [
   "App Store etkinliği yayınla",
   "Create an in-app event",
   "Add a promotional event to the store",
-  "reply to customer review",
   "Müşteri yorumuna cevap ver",
   "Bu App Store değerlendirmesine yanıt yaz",
-  "Reply to a customer review",
   "Get this month’s financial report",
   "ask for product usage metrics",
   "Analytics raporu talep et",
@@ -277,6 +275,14 @@ const KNOWN_FAILING_QUERIES: string[] = [
   "Yeni CI workflow ekle",
   "Mevcut aboneler de yeni fiyatı ödesin",
   "Dağıtım sertifikasını sil",
+  // Two entries left this list on 17 August 2026: "reply to customer review" and
+  // "Reply to a customer review". They pass, and had been passing since the
+  // tie-break change recorded in KNOWN_CONTESTED below — the FLOOR was raised to
+  // 83 to bank the win and nobody deleted the rows, so `npm test` printed "2
+  // queries started passing!" on every run until someone read it. The list is
+  // the budget: an entry that passes is not debt, it is noise that trains the
+  // reader to skip the message.
+  //
   // These two used to pass, on nothing. A Turkish suffix after an apostrophe
   // splits off a one- or two-letter token — "build'i" gives "i", "Workflow'un"
   // gives "un" — and a fragment that short is inside so many English words that


### PR DESCRIPTION
`npm test` has been printing this on every run, and the message was right:

```
[AX Debt Reduction] 2 query/queries started passing!
  - "reply to customer review"
  - "Reply to a customer review"
```

## Why they pass

Both have been passing since the tie-break change already recorded in `KNOWN_CONTESTED`: `to` became its own word rather than the one inside `customer`, the ranking tied, and a tie breaks alphabetically. `customer_review_responses.create` stopped *leading* but stayed in the top 3 — which is what the check measures.

Measured directly:

```
reply to customer review     pass true  27 results
  top3: app_store_versions.customer_reviews.list, apps.customer_review_summarizations.list, customer_review_responses.create
Reply to a customer review   pass true  12 results
  top3: customer_review_responses.create, customer_review_responses.delete, app_store_versions.customer_reviews.list
```

## Nothing regressed

`FLOOR` was raised to 83 to bank that win; the rows were never deleted. So the budget carried **184 entries against 182 actual failures** and the reminder fired forever.

```
83 passing + 116 zero-result + 66 ranked-low = 265
```

The header comment said `118 that find nothing, 64 that rank below third` — written before two queries moved between those two buckets. Corrected to 116/66.

An entry that passes is not debt, it is noise that teaches the reader to skip the message, which is what happened for twelve days. The comment left behind says so, so the next stale row gets deleted rather than inherited.