### PR TITLE
fix: pin the test run to tests/, so a worktree cannot join the suite

### DIFF
--- a/.claude/skills/heimdall-contrib/SKILL.md
+++ b/.claude/skills/heimdall-contrib/SKILL.md
@@ -100,6 +100,21 @@ a parameter description, it should be one of those rather than prose. A
 parameter description is generated, so it states itself on all 23 operations
 that take that parameter.
 
+## Running the tests
+
+`npm test` is pinned to `vitest run --dir tests`, and the `--dir` is load-bearing.
+Without it vitest globs from the repository root and collects anything test-shaped
+it finds there — including a git worktree under `.claude/worktrees/`, which is how
+one checkout became 66 files and 1016 tests instead of 33 and 508. The duplicated
+files then run in parallel against each other: `cli.test.ts` spawns processes and
+writes client config, so two copies of it fight over the same paths and fail
+differently every run. That was the whole of "four files only fail when run
+together".
+
+Rebuild before any run that spawns the binary. `gate.test.ts` and the smoke tests
+execute `dist/index.js`, so switching branches without `npm run build` measures
+the other branch's code and the failures read like logic errors.
+
 ## Measuring
 
 - `npm run ax:report` — static debt across four axes.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build": "npm run generate && tsc",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
-    "test": "vitest run",
+    "test": "vitest run --dir tests",
     "typecheck": "tsc --noEmit",
     "spec:update": "tsx scripts/update-spec.ts",
     "ax:report": "tsx scripts/ax-report.ts",


### PR DESCRIPTION
Closes MIL-219.

`vitest run` globs from the repository root and collects anything test-shaped it finds. A git worktree under `.claude/worktrees/` is test-shaped, so a checkout carrying one ran **66 files / 1016 tests** where this repository owns **33 / 508**.

That is also the whole of *"four files only fail when run together"*. The duplicated files run in parallel against each other, and `cli.test.ts` spawns processes and writes client config — two copies fight over the same paths and fail differently each time. It was contention, as the issue guessed, but between two copies of the same suite rather than within one.

## Measured both ways, with a worktree deliberately present

```
vitest run --dir tests    33 files,  508 tests
vitest run                66 files, 1016 tests
```

Three consecutive full runs are green with the fix. This was reproducible earlier today: an earlier run in this checkout reported 906 tests and two failures that could not be reproduced afterwards — the worktree had been removed in between.

## Also

The contributor skill now documents the smaller trap in the same area: `gate.test.ts` and the smoke tests spawn `dist/index.js`, so switching branches without `npm run build` measures the other branch's code and the failures read like logic errors.

Not done: putting the process-spawning tests in their own vitest project. With the glob fixed there is nothing left to isolate them from — worth revisiting only if flakiness returns inside the 33.