### PR TITLE
fix: say that a price row carries no price

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project are documented here. The format is based on 
 ## English
 ### [Unreleased]
 
+#### A price list that says it carries no prices
+`subscriptions.prices.list` was described as showing "what a subscription costs today" and returns rows with no amount and no currency — the number lives in the price point, one `include` away. A live eval session believed the description: it called the tool fifteen times, gave up, pulled all 842 price *points* instead, and reported "2.99 – 35 TRY" as the current price. The real answer was a single number.
+
+The description now says what a row actually is and names `pricing__get_subscription_price`, which resolves it in one call. Nine sibling lists have the same shape — offer prices, app prices, in-app purchase prices — and they get the instruction from a rule rather than nine hand-written strings: a list whose `include` enum offers a `*PricePoint` is a list whose rows are empty without it.
+
+That note lands on the `include` **parameter**, not the tool description, and the placement was measured. Putting it in the descriptions gave nine tools the same sentence about prices and currencies, and `subscriptions.prices.list` fell from first to fifth on *"List current subscription prices worldwide"* — two offer-price lists above it. The search ratchet caught it before it shipped.
+
+
 #### The agent harness can measure the write gate now
 `npm run ax:agent --gate` runs the corpus with the write path live and confirmation on for every write, so the gate is genuinely in the path. Every prompt is declined, so nothing reaches Apple — the decision is taken before the request is built, the same property `tests/gate.test.ts` relies on.
 
@@ -239,6 +247,14 @@ Safety and usability release: every write is now schema-checked locally, preview
 
 ## Türkçe
 ### [Unreleased]
+
+#### Fiyat taşımadığını söyleyen bir fiyat listesi
+`subscriptions.prices.list`, "bir aboneliğin bugün ne kadara mal olduğunu" gösterdiği söylenerek tarif ediliyordu ve tutar da para birimi de olmayan satırlar döndürüyor — sayı bir `include` ötedeki price point'te. Canlı bir değerlendirme oturumu açıklamaya inandı: aracı on beş kez çağırdı, pes etti, onun yerine 842 fiyat *noktasının* tamamını çekti ve güncel fiyat olarak "2,99 – 35 TRY" raporladı. Gerçek cevap tek bir sayıydı.
+
+Açıklama artık bir satırın gerçekte ne olduğunu söylüyor ve tek çağrıda çözen `pricing__get_subscription_price`'ı adıyla veriyor. Dokuz kardeş liste aynı şekle sahip — teklif fiyatları, uygulama fiyatları, uygulama içi satın alma fiyatları — ve talimatı dokuz elle yazılmış metinden değil bir kuraldan alıyorlar: `include` enum'unda bir `*PricePoint` sunan liste, o olmadan satırları boş olan listedir.
+
+O not araç açıklamasına değil, `include` **parametresine** düşüyor ve bu yerleşim ölçülerek seçildi. Açıklamalara koyunca dokuz araç fiyat ve para birimi hakkında aynı cümleyi taşıdı ve `subscriptions.prices.list`, *"List current subscription prices worldwide"* sorgusunda birincilikten beşinciliğe düştü — üstünde iki teklif-fiyatı listesi vardı. Arama ratchet'i bunu yayınlanmadan yakaladı.
+
 
 #### Ajan harness'ı artık yazma kapısını ölçebiliyor
 `npm run ax:agent --gate`, korpusu yazma yolu canlıyken ve her yazmada onay açıkken koşuyor; yani kapı gerçekten yolun içinde. Her istem reddediliyor, dolayısıyla Apple'a hiçbir şey ulaşmıyor — karar istek kurulmadan önce veriliyor, `tests/gate.test.ts`'in dayandığı özelliğin aynısı.

--- a/scripts/describe.ts
+++ b/scripts/describe.ts
@@ -243,7 +243,11 @@ export const CURATED: Record<string, string> = {
     'Cancel a scheduled subscription price change before it takes effect.',
   'subscriptions.prices.list':
     'List the current and scheduled prices of a subscription per territory (country) — ' +
-    'use this to see what a subscription costs today in each storefront.',
+    'what a subscription costs today in each storefront. Each row is a start date and a ' +
+    'reference: the amount and the currency live in the price point, so a row read ' +
+    'without include=subscriptionPricePoint,territory carries no price at all. ' +
+    'pricing__get_subscription_price resolves that in one call, for one country or for ' +
+    'every one.',
   'subscription_price_points.equalizations.list':
     'Given one price point in a base country, list the equivalent (equalized) price ' +
     'points in every other territory — for per-country pricing aligned to one anchor price.',

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -211,6 +211,46 @@ const PARAM_NOTES: Array<[RegExp, string]> = [
  */
 const RELATIONSHIP_FILTER = /id\(s\) of related '([^']+)'\s*$/i;
 
+/**
+ * A price list that carries no price until you ask for one.
+ *
+ * This lands on the `include` PARAMETER, not on the tool description, and that
+ * placement is the whole design. `searchOperations` ranks on
+ * `name + description + path`, so nine tools carrying the same sentence about
+ * prices and currencies is nine tools competing for every price query: the
+ * first attempt put this text in the descriptions and dropped
+ * `subscriptions.prices.list` from first to fifth on "List current subscription
+ * prices worldwide", with two offer-price lists above it. The information is
+ * needed at the moment the model fills in parameters, which is where it now is.
+ *
+ * `/subscriptions/{id}/prices` and its five siblings return JSON:API
+ * relationship stubs — `{type, id}` and a start date, no number, no currency.
+ * The description promised "what a subscription costs today" and a live session
+ * believed it: fifteen calls to the same tool, then it gave up, pulled all 842
+ * price *points* instead and reported a range as the current price. The real
+ * answer was one number.
+ *
+ * The tell is machine-readable, so this is a rule rather than six curated
+ * strings: a list whose `include` enum offers a `*PricePoint` is a list whose
+ * rows are empty without it. Apple adds more of these; a hand-written set would
+ * not cover them.
+ */
+function pricePointIncludeNote(paramName: string, values: string[] | undefined): string | undefined {
+  if (paramName !== 'include') return undefined;
+  const pricePoint = values?.find((v) => /PricePoint$/.test(v));
+  if (!pricePoint) return undefined;
+  const parts = [pricePoint, ...(values!.includes('territory') ? ['territory'] : [])];
+  // No macro named here. `pricing__get_subscription_price` answers the base
+  // price of a subscription and nothing else — pointing an app price list, an
+  // in-app purchase list or an introductory-offer list at it would be the same
+  // class of wrong pointer this rule exists to remove. That sentence belongs on
+  // the one tool it is true for, in CURATED.
+  return (
+    `ALWAYS pass include=${parts.join(',')} — without it every row is an opaque ` +
+    `id with no price and no currency, which reads as "there is no price here".`
+  );
+}
+
 function annotateParam(name: string, description: string): string {
   const note = PARAM_NOTES.find(([pattern]) => pattern.test(name))?.[1];
   if (note) return description ? `${description} ${note}` : note;
@@ -468,10 +508,12 @@ function main(): void {
         .map((p) => ({
           name: p.name,
           type: schemaType(p.schema),
-          description: annotateParam(
-            p.name,
-            (p.description ?? '').replace(/\s+/g, ' ').slice(0, 200)
-          ),
+          description: [
+            annotateParam(p.name, (p.description ?? '').replace(/\s+/g, ' ').slice(0, 200)),
+            pricePointIncludeNote(p.name, enumValues(p.schema)),
+          ]
+            .filter(Boolean)
+            .join(' '),
           enum: enumValues(p.schema)?.slice(0, 40),
           ...(p.required ? { required: true } : {}),
         }));
@@ -505,13 +547,17 @@ function main(): void {
         domain: domainFor(rootResource(path)),
         method: method.toUpperCase(),
         path,
-        description: describe({
-          operationId: op.operationId,
-          method: method.toUpperCase(),
-          path,
-          toolName: name,
-          deprecated: Boolean(op.deprecated),
-        }),
+        description: [
+          describe({
+            operationId: op.operationId,
+            method: method.toUpperCase(),
+            path,
+            toolName: name,
+            deprecated: Boolean(op.deprecated),
+          }),
+        ]
+          .filter(Boolean)
+          .join(' '),
         readOnly: method === 'get',
         deprecated: Boolean(op.deprecated),
         pathParams,

--- a/src/generated/operations.ts
+++ b/src/generated/operations.ts
@@ -3777,7 +3777,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "include",
         "type": "array",
-        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned.",
+        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned. ALWAYS pass include=appPricePoint,territory — without it every row is an opaque id with no price and no currency, which reads as \"there is no price here\".",
         "enum": [
           "appPricePoint",
           "territory"
@@ -3886,7 +3886,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "include",
         "type": "array",
-        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned.",
+        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned. ALWAYS pass include=appPricePoint,territory — without it every row is an opaque id with no price and no currency, which reads as \"there is no price here\".",
         "enum": [
           "appPricePoint",
           "territory"
@@ -22061,7 +22061,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "include",
         "type": "array",
-        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned.",
+        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned. ALWAYS pass include=inAppPurchasePricePoint,territory — without it every row is an opaque id with no price and no currency, which reads as \"there is no price here\".",
         "enum": [
           "inAppPurchasePricePoint",
           "territory"
@@ -22158,7 +22158,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "include",
         "type": "array",
-        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned.",
+        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned. ALWAYS pass include=inAppPurchasePricePoint,territory — without it every row is an opaque id with no price and no currency, which reads as \"there is no price here\".",
         "enum": [
           "inAppPurchasePricePoint",
           "territory"
@@ -26199,7 +26199,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "include",
         "type": "array",
-        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned.",
+        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned. ALWAYS pass include=subscriptionPricePoint,territory — without it every row is an opaque id with no price and no currency, which reads as \"there is no price here\".",
         "enum": [
           "territory",
           "subscriptionPricePoint"
@@ -26577,7 +26577,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "include",
         "type": "array",
-        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned.",
+        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned. ALWAYS pass include=subscriptionPricePoint,territory — without it every row is an opaque id with no price and no currency, which reads as \"there is no price here\".",
         "enum": [
           "territory",
           "subscriptionPricePoint"
@@ -26899,7 +26899,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "include",
         "type": "array",
-        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned.",
+        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned. ALWAYS pass include=subscriptionPricePoint,territory — without it every row is an opaque id with no price and no currency, which reads as \"there is no price here\".",
         "enum": [
           "subscription",
           "territory",
@@ -27037,7 +27037,7 @@ export const OPERATIONS: Operation[] = [
     "domain": "subscriptions",
     "method": "GET",
     "path": "/v1/subscriptions/{id}/prices",
-    "description": "List the current and scheduled prices of a subscription per territory (country) — use this to see what a subscription costs today in each storefront.",
+    "description": "List the current and scheduled prices of a subscription per territory (country) — what a subscription costs today in each storefront. Each row is a start date and a reference: the amount and the currency live in the price point, so a row read without include=subscriptionPricePoint,territory carries no price at all. pricing__get_subscription_price resolves that in one call, for one country or for every one.",
     "readOnly": true,
     "deprecated": false,
     "pathParams": [
@@ -27071,7 +27071,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "include",
         "type": "array",
-        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned.",
+        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned. ALWAYS pass include=subscriptionPricePoint,territory — without it every row is an opaque id with no price and no currency, which reads as \"there is no price here\".",
         "enum": [
           "territory",
           "subscriptionPricePoint"
@@ -28012,7 +28012,7 @@ export const OPERATIONS: Operation[] = [
       {
         "name": "include",
         "type": "array",
-        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned.",
+        "description": "comma-separated list of relationships to include Pull related records in the same call. Without it, checking a relationship costs one extra call per row returned. ALWAYS pass include=subscriptionPricePoint,territory — without it every row is an opaque id with no price and no currency, which reads as \"there is no price here\".",
         "enum": [
           "territory",
           "subscriptionPricePoint"


### PR DESCRIPTION
Closes MIL-205.

`subscriptions.prices.list` was described as showing *"what a subscription costs today"* and returns rows with no amount and no currency — the number lives in the price point, one `include` away.

A live eval session believed the description: fifteen calls to the same tool, then it gave up, pulled all 842 price *points* instead, and reported `2.99 – 35 TRY` as the current price. The real answer was a single number.

## The rule, not nine strings

Nine sibling lists have the same shape — offer prices, app prices, in-app purchase prices. A list whose `include` enum offers a `*PricePoint` is a list whose rows are empty without it, which is machine-readable, so Apple's next one inherits the instruction.

## Placement was measured, not assumed

The note lands on the `include` **parameter**, not the tool description.

`searchOperations` ranks on `name + description + path`. Putting the sentence in nine descriptions gave nine tools the same price vocabulary, and `subscriptions.prices.list` fell **from first to fifth** on *"List current subscription prices worldwide"* — two offer-price lists above it. The search ratchet failed the build before it shipped.

## The curated text keeps the words people type

A cleaner rewrite that dropped "current", "costs today" and "storefront" cost two more intents on its own. A description that is true and unfindable is not an improvement, so the correction is appended to the original opening rather than replacing it.

Only `subscriptions.prices.list` names `pricing__get_subscription_price`. That macro answers the base price of a subscription, so pointing an app price list or an introductory-offer list at it would be the same class of wrong pointer this issue is about.

504 tests passing, all four ratchets green.