### PR TITLE
fix: stop the StoreKit reads promising fields they do not return

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project are documented here. The format is based on 
 ## English
 ### [Unreleased]
 
+#### StoreKit reads stop promising fields they do not return
+`storekit__get_transaction_info` advertised "the decoded details of a single transaction: product, price, dates, ownership type and revocation state" and returns one signed JWS string. The history, refund and entitlement tools do the same with whole arrays of them. A caller planning around five named fields receives `header.payload.signature`, nothing crashes, and there is no way to tell whether the wrong tool was called.
+
+The descriptions now say the payloads are signed and that the caller verifies and decodes them, with the App Store Server Library's `SignedDataVerifier` named once rather than on all four — repeating it put the word "certificates" into four descriptions and took the top of "create certificate" off `certificates.create`.
+
+Returning the sealed envelope stays the behaviour. `jwsClaim` could open it in two lines, and those are the wrong two lines: it base64-decodes without checking the signature, which is presenting unverified data as fact. Decoding properly needs Apple's roots and a decision about what happens when verification fails, which is MIL-218 — now named in a code comment so the next reader knows the envelope is the interim answer rather than the intended one.
+
+
 #### A price list that says it carries no prices
 `subscriptions.prices.list` was described as showing "what a subscription costs today" and returns rows with no amount and no currency — the number lives in the price point, one `include` away. A live eval session believed the description: it called the tool fifteen times, gave up, pulled all 842 price *points* instead, and reported "2.99 – 35 TRY" as the current price. The real answer was a single number.
 
@@ -247,6 +255,14 @@ Safety and usability release: every write is now schema-checked locally, preview
 
 ## Türkçe
 ### [Unreleased]
+
+#### StoreKit okumaları döndürmedikleri alanları vaat etmeyi bıraktı
+`storekit__get_transaction_info` kendini "tek bir işlemin çözülmüş detayları: ürün, fiyat, tarihler, sahiplik tipi ve iptal durumu" diye tanıtıyor ve imzalı tek bir JWS metni döndürüyor. Geçmiş, iade ve yetki araçları aynısını dizilerle yapıyor. Beş isimli alana göre plan yapan bir çağıran `header.payload.signature` alıyor, hiçbir şey çökmüyor ve yanlış aracı çağırıp çağırmadığını anlamanın yolu yok.
+
+Açıklamalar artık yüklerin imzalı olduğunu ve çözmenin çağırana ait olduğunu söylüyor. App Store Server Library'nin `SignedDataVerifier`'ı dördünde değil bir kez adlandırılıyor — dördüne birden yazmak "certificates" kelimesini dört açıklamaya sokup "create certificate" sorgusunun birinciliğini `certificates.create`'ten aldı.
+
+Mühürlü zarfı döndürmek davranış olarak kalıyor. `jwsClaim` onu iki satırda açabilir ve o iki satır yanlış olanlar: imzayı kontrol etmeden base64 çözüyor, yani doğrulanmamış veriyi gerçek gibi sunuyor. Düzgün çözmek Apple'ın kök sertifikalarını ve doğrulama başarısız olunca ne olacağına dair bir kararı gerektiriyor — o da MIL-218. Bir kod yorumu artık onu adıyla anıyor, ki sonraki okuyan zarfın geçici cevap olduğunu bilsin.
+
 
 #### Fiyat taşımadığını söyleyen bir fiyat listesi
 `subscriptions.prices.list`, "bir aboneliğin bugün ne kadara mal olduğunu" gösterdiği söylenerek tarif ediliyordu ve tutar da para birimi de olmayan satırlar döndürüyor — sayı bir `include` ötedeki price point'te. Canlı bir değerlendirme oturumu açıklamaya inandı: aracı on beş kez çağırdı, pes etti, onun yerine 842 fiyat *noktasının* tamamını çekti ve güncel fiyat olarak "2,99 – 35 TRY" raporladı. Gerçek cevap tek bir sayıydı.

--- a/src/storekit/index.ts
+++ b/src/storekit/index.ts
@@ -73,8 +73,9 @@ export const STOREKIT_TOOLS: McpToolDefinition[] = [
     name: 'storekit__get_transaction_history',
     description:
       "Get a customer's full purchase history from any one of their transaction IDs. " +
-      'Supports filtering by product type, product ID and date range. ' +
-      '[App Store Server API]',
+      'Supports filtering by product type, product ID and date range. Returns Apple\'s ' +
+      'SIGNED transactions (JWS strings), not decoded fields — verify and decode them ' +
+      'before reading. [App Store Server API]',
     inputSchema: {
       type: 'object',
       properties: {
@@ -104,8 +105,10 @@ export const STOREKIT_TOOLS: McpToolDefinition[] = [
   {
     name: 'storekit__get_transaction_info',
     description:
-      'Get the decoded details of a single transaction: product, price, dates, ' +
-      'ownership type and revocation state. [App Store Server API]',
+      'Get a single transaction: product, price, dates, ownership type and revocation ' +
+      'state — as Apple\'s SIGNED payload (a JWS string), not as decoded fields. ' +
+      "Verify and decode it with the App Store Server Library's SignedDataVerifier, or " +
+      "any JWS verifier configured with Apple's roots. [App Store Server API]",
     inputSchema: {
       type: 'object',
       properties: {
@@ -119,8 +122,9 @@ export const STOREKIT_TOOLS: McpToolDefinition[] = [
     name: 'storekit__get_subscription_statuses',
     description:
       "Get the status of every subscription a customer holds, including expiry date, " +
-      'auto-renew state, billing retry and grace period. Use this for entitlement ' +
-      'checks. [App Store Server API]',
+      'auto-renew state, billing retry and grace period. Apple returns those fields ' +
+      'inside SIGNED payloads (JWS strings) on each item, so verify and decode them ' +
+      'before reading. Use this for entitlement checks. [App Store Server API]',
     inputSchema: {
       type: 'object',
       properties: {
@@ -143,8 +147,9 @@ export const STOREKIT_TOOLS: McpToolDefinition[] = [
     name: 'storekit__check_entitlement',
     description:
       'Answer the single question "does this customer currently have access?". ' +
-      'Returns a boolean plus the active subscriptions backing it. ' +
-      'Optionally narrow to one product ID. [App Store Server API]',
+      'Returns a boolean plus the active subscriptions backing it — those come back as ' +
+      'Apple\'s SIGNED payloads (JWS strings), so verify and decode them before reading ' +
+      'any field. Optionally narrow to one product ID. [App Store Server API]',
     inputSchema: {
       type: 'object',
       properties: {
@@ -317,6 +322,12 @@ export class StoreKitService {
         return this.transactionHistory(client, args);
 
       case 'storekit__get_transaction_info': {
+        // The sealed envelope, on purpose. `jwsClaim` above can open one in two
+        // lines, and those are the wrong two lines: it splits on `.` and
+        // base64-decodes without checking the signature, which is presenting
+        // unverified data as fact. Handing the JWS back is the honest of the
+        // two behaviours until MIL-218 threads Apple's roots through and
+        // decides what happens when verification fails.
         const res = await client.getTransactionInfo(args.transaction_id);
         return { signedTransactionInfo: res.signedTransactionInfo };
       }


### PR DESCRIPTION
Closes MIL-216.

`storekit__get_transaction_info` advertised *"the decoded details of a single transaction: product, price, dates, ownership type and revocation state"* and returns one signed JWS string. The history, refund and entitlement tools do the same with whole arrays of them.

A caller planning around five named fields receives `header.payload.signature`. Nothing crashes, and there is no way to tell whether the wrong tool was called.

## Description text only

Returning the sealed envelope stays the behaviour, deliberately. `jwsClaim` could open it in two lines and those are the wrong two lines: it splits on `.` and base64-decodes **without checking the signature**, which is presenting unverified data as fact.

Decoding properly needs Apple's roots threaded through and a decision about what happens when verification fails — that is MIL-218, now named in a code comment at the return site so the next reader knows the envelope is the interim answer rather than an oversight.

## One mention, not four

`SignedDataVerifier` is named once, on `get_transaction_info`. Naming it on all four put the word "certificates" into four descriptions and took the top of *"create certificate"* away from `certificates.create`:

```
- certificates.create, profiles.create, accessibility_declarations.create
+ storekit__get_transaction_history, storekit__get_transaction_info, certificates.create
```

Same vocabulary collision as #63 an hour earlier, caught by the same ratchet. The other three say the payloads are signed and stop there.

504 tests passing.