### PR TITLE
feat: verify a StoreKit payload before decoding it

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project are documented here. The format is based on 
 ## English
 ### [Unreleased]
 
+#### StoreKit reads can return verified fields instead of a sealed envelope
+Set `ASC_APPLE_ROOT_CERTS` to Apple's DER root certificates — paths, or one directory — and `storekit__get_transaction_info`, `storekit__get_transaction_history` and `storekit__get_refund_history` verify each payload with the App Store Server Library and return decoded fields. Leave it unset and they return the signed payloads exactly as before, which is what their descriptions already promised. Every response says which one it is, so a caller never has to infer it.
+
+Nothing is decoded without being checked. A payload that fails verification is an error, not fields with a caveat attached: the point of verifying is that the result can be treated as fact, and "here are the values, but we could not confirm them" invites the reading it was supposed to prevent.
+
+The decoded shape is an allowlist rather than Apple's whole payload. `appAccountToken` is left out deliberately — it is the UUID a developer maps to their own user record, so a transaction id becomes a route back to an account inside their app, and none of these tools was asked for that. `raw: true` returns the signed payload for anyone who wants to verify it themselves.
+
+No certificates ship in this package. They are Apple's to publish and one more thing to keep current, and a stale one would turn verification into a silent no.
+
+
 #### StoreKit reads stop promising fields they do not return
 `storekit__get_transaction_info` advertised "the decoded details of a single transaction: product, price, dates, ownership type and revocation state" and returns one signed JWS string. The history, refund and entitlement tools do the same with whole arrays of them. A caller planning around five named fields receives `header.payload.signature`, nothing crashes, and there is no way to tell whether the wrong tool was called.
 
@@ -255,6 +265,16 @@ Safety and usability release: every write is now schema-checked locally, preview
 
 ## Türkçe
 ### [Unreleased]
+
+#### StoreKit okumaları mühürlü zarf yerine doğrulanmış alan döndürebiliyor
+`ASC_APPLE_ROOT_CERTS`'i Apple'ın DER kök sertifikalarına ayarlayın — dosya yolları ya da tek bir dizin — ve `storekit__get_transaction_info`, `storekit__get_transaction_history`, `storekit__get_refund_history` her yükü App Store Server Library ile doğrulayıp çözülmüş alanlar döndürsün. Ayarlamazsanız eskisi gibi imzalı yükleri döndürüyorlar; açıklamalarının zaten vaat ettiği şey de bu. Her cevap hangisi olduğunu söylüyor, çağıranın tahmin etmesi gerekmiyor.
+
+Kontrol edilmeden hiçbir şey çözülmüyor. Doğrulaması başarısız olan bir yük, kenarına şerh düşülmüş alanlar değil, hatadır: doğrulamanın amacı sonucun gerçek gibi kullanılabilmesi ve "işte değerler, ama teyit edemedik" tam da engellemesi gereken okumayı davet ediyor.
+
+Çözülmüş şekil, Apple'ın tüm yükü değil bir beyaz liste. `appAccountToken` bilerek dışarıda — geliştiricinin kendi kullanıcı kaydına eşlediği UUID o, yani bir işlem kimliği uygulamasındaki bir hesaba geri dönüş yolu oluyor ve bu araçların hiçbiri onu istemedi. `raw: true` kendisi doğrulamak isteyene imzalı yükü veriyor.
+
+Bu pakette hiçbir sertifika taşınmıyor. Onlar Apple'ın yayınladığı şeyler ve güncel tutulması gereken bir kalem daha; bayat kalan bir tanesi doğrulamayı sessiz bir hayıra çevirirdi.
+
 
 #### StoreKit okumaları döndürmedikleri alanları vaat etmeyi bıraktı
 `storekit__get_transaction_info` kendini "tek bir işlemin çözülmüş detayları: ürün, fiyat, tarihler, sahiplik tipi ve iptal durumu" diye tanıtıyor ve imzalı tek bir JWS metni döndürüyor. Geçmiş, iade ve yetki araçları aynısını dizilerle yapıyor. Beş isimli alana göre plan yapan bir çağıran `header.payload.signature` alıyor, hiçbir şey çökmüyor ve yanlış aracı çağırıp çağırmadığını anlamanın yolu yok.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -201,6 +201,7 @@ The App Store Server API answers questions about individual customers rather tha
 | `ASC_BUNDLE_ID` | no | Enables App Store Server API (StoreKit 2) tools |
 | `ASC_APP_APPLE_ID` | no | Your app's numeric Apple ID |
 | `ASC_ENVIRONMENT` | no | `Sandbox` (default) or `Production`, for StoreKit 2 |
+| `ASC_APPLE_ROOT_CERTS` | no | Paths (or one directory) of Apple's DER root certificates. Set it and the StoreKit reads return verified, decoded fields; unset they return Apple's signed payloads |
 | `ASC_DOMAINS` | no | Comma-separated domains to load, or `all` (env form of `--domains`) |
 | `ASC_READ_ONLY` | no | `true` to expose only non-mutating tools |
 | `ASC_CONFIRM_WRITES` | no | `1` / `true` to ask before every write, `0` / `false` to never ask (default: only the strong risk levels) |
@@ -546,6 +547,7 @@ App Store Server API, listeniz hakkında değil tek tek müşteriler hakkında s
 | `ASC_BUNDLE_ID` | hayır | App Store Server API (StoreKit 2) araçlarını etkinleştirir |
 | `ASC_APP_APPLE_ID` | hayır | Uygulamanın sayısal Apple ID'si |
 | `ASC_ENVIRONMENT` | hayır | StoreKit 2 için `Sandbox` (varsayılan) veya `Production` |
+| `ASC_APPLE_ROOT_CERTS` | hayır | Apple'ın DER kök sertifikalarının yolları (ya da tek bir dizin). Ayarlıysa StoreKit okumaları doğrulanmış ve çözülmüş alanlar döndürür; ayarlı değilse Apple'ın imzalı yüklerini döndürür |
 | `ASC_DOMAINS` | hayır | Yüklenecek domainler, virgülle ayrılmış ya da `all` |
 | `ASC_READ_ONLY` | hayır | Yalnızca değiştirmeyen araçları göstermek için `true` |
 | `ASC_CONFIRM_WRITES` | hayır | Her yazmadan önce sormak için `1` / `true`, hiç sormamak için `0` / `false` (varsayılan: yalnızca güçlü risk seviyeleri) |

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,6 +13,8 @@ export interface ServerConfig {
     bundleId: string;
     appAppleId?: number;
     environment: 'Sandbox' | 'Production';
+    /** Paths to Apple's DER root certificates; enables verified decoding. */
+    appleRootCerts?: string[];
   };
   /** When set, only these domains are exposed as tools. */
   domains?: string[];
@@ -139,6 +141,12 @@ export function loadConfig(argv: string[] = process.argv.slice(2)): ServerConfig
             (env.ASC_ENVIRONMENT ?? shared?.environment) === 'Production'
               ? 'Production'
               : 'Sandbox',
+          // Apple's DER root certificates, which the App Store Server Library
+          // asks the caller for rather than shipping. Comma-separated paths, or
+          // one directory. Unset means the StoreKit reads keep handing back the
+          // signed envelope — the honest default, since decoding without
+          // verifying would present unverified data as fact.
+          appleRootCerts: parseList(env.ASC_APPLE_ROOT_CERTS),
         }
       : undefined,
     domains: parseList(option('domains') ?? env.ASC_DOMAINS),

--- a/src/storekit/index.ts
+++ b/src/storekit/index.ts
@@ -11,6 +11,7 @@ import {
   Environment,
   ExtendReasonCode,
   GetTransactionHistoryVersion,
+  SignedDataVerifier,
   Status,
   type ExtendRenewalDateRequest,
   type HistoryResponse,
@@ -24,7 +25,9 @@ import {
   type SubscriptionGroupIdentifierItem,
   type TransactionHistoryRequest,
 } from '@apple/app-store-server-library';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { AscApiError } from '../core/errors.js';
 import type { McpToolDefinition } from '../core/registry.js';
 import type { ServerConfig } from '../core/config.js';
 
@@ -45,6 +48,76 @@ function jwsClaim(jws: string | undefined, claim: string): unknown {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * What a decoded transaction is allowed to carry into a model's context.
+ *
+ * Apple's payload holds more than any of these tools was asked for, and
+ * `appAccountToken` is the sharp one: it is the UUID a developer maps to their
+ * own user record, so a transaction id becomes a route back to an account
+ * inside their app. Nothing here needs it, so nothing here returns it. Anyone
+ * who does need the full payload asks for `raw`, verifies it themselves, and
+ * makes that choice deliberately.
+ */
+const TRANSACTION_FIELDS = [
+  'transactionId',
+  'originalTransactionId',
+  'productId',
+  'purchaseDate',
+  'expiresDate',
+  'quantity',
+  'type',
+  'inAppOwnershipType',
+  'revocationDate',
+  'revocationReason',
+  'isUpgraded',
+  'offerType',
+  'storefront',
+  'currency',
+  'price',
+] as const;
+
+/**
+ * Reads Apple's DER roots from paths, or from a directory of them.
+ *
+ * The library asks the caller for these rather than shipping them, and this
+ * repository does not ship them either: a certificate committed here is one
+ * more thing to keep current, and getting it wrong turns verification into a
+ * silent no. Unset is a supported state — the reads then return the signed
+ * envelope, which is what their descriptions already say.
+ */
+function readRootCertificates(paths: string[] | undefined): Buffer[] {
+  if (!paths?.length) return [];
+  const files: string[] = [];
+  for (const entry of paths) {
+    try {
+      if (statSync(entry).isDirectory()) {
+        files.push(...readdirSync(entry).filter((f) => /\.(cer|der|crt)$/i.test(f)).map((f) => join(entry, f)));
+      } else {
+        files.push(entry);
+      }
+    } catch {
+      // A path that is not there is a configuration mistake, and it surfaces
+      // below as "no roots" rather than as a crash at startup — the server has
+      // 24 other tools that do not need them.
+    }
+  }
+  return files.flatMap((f) => {
+    try {
+      return [readFileSync(f)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function pickTransactionFields(decoded: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of TRANSACTION_FIELDS) {
+    if (decoded[key] !== undefined) out[key] = decoded[key];
+  }
+  return out;
 }
 
 /**
@@ -74,8 +147,8 @@ export const STOREKIT_TOOLS: McpToolDefinition[] = [
     description:
       "Get a customer's full purchase history from any one of their transaction IDs. " +
       'Supports filtering by product type, product ID and date range. Returns Apple\'s ' +
-      'SIGNED transactions (JWS strings), not decoded fields — verify and decode them ' +
-      'before reading. [App Store Server API]',
+      'SIGNED transactions (JWS strings) unless ASC_APPLE_ROOT_CERTS is set, in which ' +
+      'case they arrive verified and decoded. [App Store Server API]',
     inputSchema: {
       type: 'object',
       properties: {
@@ -84,6 +157,13 @@ export const STOREKIT_TOOLS: McpToolDefinition[] = [
           description: 'Any transaction ID belonging to the customer.',
         },
         product_id: { type: 'string', description: 'Filter to one product ID.' },
+        raw: {
+          type: 'boolean',
+          description:
+            'Return Apple\'s signed JWS payloads instead of decoded fields, to verify them ' +
+            'yourself. Ignored when ASC_APPLE_ROOT_CERTS is unset — the payloads are all ' +
+            'there is then.',
+        },
         product_type: {
           type: 'string',
           enum: ['AUTO_RENEWABLE', 'NON_RENEWABLE', 'CONSUMABLE', 'NON_CONSUMABLE'],
@@ -106,13 +186,20 @@ export const STOREKIT_TOOLS: McpToolDefinition[] = [
     name: 'storekit__get_transaction_info',
     description:
       'Get a single transaction: product, price, dates, ownership type and revocation ' +
-      'state — as Apple\'s SIGNED payload (a JWS string), not as decoded fields. ' +
-      "Verify and decode it with the App Store Server Library's SignedDataVerifier, or " +
-      "any JWS verifier configured with Apple's roots. [App Store Server API]",
+      'state. Set ASC_APPLE_ROOT_CERTS and the payload arrives verified and decoded; ' +
+      "without it you get Apple's SIGNED payload (a JWS string) to verify yourself with " +
+      "the App Store Server Library. [App Store Server API]",
     inputSchema: {
       type: 'object',
       properties: {
         transaction_id: { type: 'string', description: 'Transaction ID to look up.' },
+        raw: {
+          type: 'boolean',
+          description:
+            'Return Apple\'s signed JWS payloads instead of decoded fields, to verify them ' +
+            'yourself. Ignored when ASC_APPLE_ROOT_CERTS is unset — the payloads are all ' +
+            'there is then.',
+        },
       },
       required: ['transaction_id'],
     },
@@ -170,13 +257,22 @@ export const STOREKIT_TOOLS: McpToolDefinition[] = [
     name: 'storekit__get_refund_history',
     description:
       'List every refunded transaction for a customer. Useful for auditing refund ' +
-      'abuse before granting goodwill credit. [App Store Server API]',
+      'abuse before granting goodwill credit. Returns Apple\'s SIGNED transactions ' +
+      '(JWS strings) unless ASC_APPLE_ROOT_CERTS is set, in which case they arrive ' +
+      'verified and decoded. [App Store Server API]',
     inputSchema: {
       type: 'object',
       properties: {
         transaction_id: {
           type: 'string',
           description: 'Any transaction ID belonging to the customer.',
+        },
+        raw: {
+          type: 'boolean',
+          description:
+            'Return Apple\'s signed JWS payloads instead of decoded fields, to verify them ' +
+            'yourself. Ignored when ASC_APPLE_ROOT_CERTS is unset — the payloads are all ' +
+            'there is then.',
         },
       },
       required: ['transaction_id'],
@@ -276,6 +372,10 @@ export class StoreKitService {
   private readonly issuerId: string;
   private readonly bundleId: string;
   private readonly defaultEnvironment: 'Production' | 'Sandbox';
+  private readonly appAppleId?: number;
+  /** Apple's DER roots, read once. Empty means verified decoding is off. */
+  private readonly rootCertificates: Buffer[];
+  private readonly verifiers = new Map<'Production' | 'Sandbox', SignedDataVerifier>();
   // One transaction lives in exactly one environment, so callers can override
   // per request; clients are built lazily and cached per environment.
   private readonly clients = new Map<'Production' | 'Sandbox', AppStoreServerAPIClient>();
@@ -293,6 +393,100 @@ export class StoreKitService {
     this.issuerId = config.credentials.issuerId;
     this.bundleId = config.storekit.bundleId;
     this.defaultEnvironment = config.storekit.environment === 'Production' ? 'Production' : 'Sandbox';
+    this.appAppleId = config.storekit.appAppleId;
+    this.rootCertificates = readRootCertificates(config.storekit.appleRootCerts);
+  }
+
+  /** True when a caller configured Apple's roots, so payloads can be verified. */
+  private get canVerify(): boolean {
+    return this.rootCertificates.length > 0;
+  }
+
+  private verifierFor(env: 'Production' | 'Sandbox'): SignedDataVerifier {
+    let verifier = this.verifiers.get(env);
+    if (!verifier) {
+      try {
+        verifier = this.buildVerifier(env);
+      } catch (err) {
+        // A file that is not a DER certificate fails here, inside OpenSSL, with
+        // a message nobody can act on ("PEM routines::no start line"). Say what
+        // was being attempted and with what.
+        throw new AscApiError(
+          `ASC_APPLE_ROOT_CERTS does not parse as Apple's DER root certificates: ` +
+            `${(err as Error).message}. Point it at the .cer files Apple publishes, or ` +
+            `unset it to receive the signed payloads instead.`,
+          0
+        );
+      }
+      this.verifiers.set(env, verifier);
+    }
+    return verifier;
+  }
+
+  private buildVerifier(env: 'Production' | 'Sandbox'): SignedDataVerifier {
+    return new SignedDataVerifier(
+      this.rootCertificates,
+      // Online checks fetch Apple's CRLs on every call. Off: the roots pin the
+      // chain, and a read tool should not add a second network dependency whose
+      // outage looks like a verification failure.
+      false,
+      env === 'Production' ? Environment.PRODUCTION : Environment.SANDBOX,
+      this.bundleId,
+      this.appAppleId
+    );
+  }
+
+  /**
+   * Verified fields, or the sealed envelope — never a decode without a check.
+   *
+   * A failure is an error rather than a warning attached to data. The whole
+   * point of verifying is that the caller can treat what comes back as fact;
+   * handing back "here are the fields, but we could not confirm them" invites
+   * exactly the reading it was supposed to prevent.
+   */
+  private async decode(
+    signed: string[],
+    env: 'Production' | 'Sandbox',
+    raw: boolean
+  ): Promise<unknown[]> {
+    if (raw || !this.canVerify) return signed;
+    const verifier = this.verifierFor(env);
+    const out: unknown[] = [];
+    for (const jws of signed) {
+      try {
+        const decoded = await verifier.verifyAndDecodeTransaction(jws);
+        out.push(pickTransactionFields(decoded as unknown as Record<string, unknown>));
+      } catch (err) {
+        throw new AscApiError(
+          `A transaction payload failed signature verification: ${(err as Error).message}. ` +
+            `Nothing was decoded. Check that ASC_APPLE_ROOT_CERTS points at Apple's current ` +
+            `root certificates and that the environment (${env}) matches the transaction.`,
+          0
+        );
+      }
+    }
+    return out;
+  }
+
+  /** The environment a call runs against: the argument, else the default. */
+  private envFor(environment?: unknown): 'Production' | 'Sandbox' {
+    return environment === 'Production' || environment === 'Sandbox'
+      ? environment
+      : this.defaultEnvironment;
+  }
+
+  /**
+   * The shape both history tools return: decoded fields when verification is
+   * available and not waived, the signed array otherwise. `verified` is stated
+   * either way so a caller never has to infer which one it got.
+   */
+  private async envelopeOrFields(
+    signed: string[],
+    args: Record<string, any>
+  ): Promise<Record<string, unknown>> {
+    const raw = Boolean(args.raw);
+    if (raw || !this.canVerify) return { signedTransactions: signed, verified: false };
+    return { transactions: await this.decode(signed, this.envFor(args.environment), false), verified: true };
   }
 
   /** Client for the requested environment, or the configured default. */
@@ -322,14 +516,12 @@ export class StoreKitService {
         return this.transactionHistory(client, args);
 
       case 'storekit__get_transaction_info': {
-        // The sealed envelope, on purpose. `jwsClaim` above can open one in two
-        // lines, and those are the wrong two lines: it splits on `.` and
-        // base64-decodes without checking the signature, which is presenting
-        // unverified data as fact. Handing the JWS back is the honest of the
-        // two behaviours until MIL-218 threads Apple's roots through and
-        // decides what happens when verification fails.
         const res = await client.getTransactionInfo(args.transaction_id);
-        return { signedTransactionInfo: res.signedTransactionInfo };
+        const signed = res.signedTransactionInfo ? [res.signedTransactionInfo] : [];
+        const [one] = await this.decode(signed, this.envFor(args.environment), Boolean(args.raw));
+        return this.canVerify && !args.raw
+          ? { transaction: one ?? null, verified: true }
+          : { signedTransactionInfo: res.signedTransactionInfo, verified: false };
       }
 
       case 'storekit__get_subscription_statuses':
@@ -362,7 +554,7 @@ export class StoreKitService {
           }
         }
         return {
-          signedTransactions: items,
+          ...(await this.envelopeOrFields(items, args)),
           count: items.length,
           ...truncation(hasMore, revision, 'the 10-page cap'),
         };
@@ -453,7 +645,7 @@ export class StoreKitService {
     }
 
     return {
-      signedTransactions: transactions,
+      ...(await this.envelopeOrFields(transactions, args)),
       count: transactions.length,
       ...truncation(hasMore, revision, 'max_pages'),
     };

--- a/tests/storekit-verify.test.ts
+++ b/tests/storekit-verify.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { StoreKitService } from '../src/storekit/index.js';
+import type { ServerConfig } from '../src/core/config.js';
+
+const base: ServerConfig = {
+  credentials: {
+    keyId: 'AAAAAAAAAA',
+    issuerId: '00000000-0000-0000-0000-000000000000',
+    privateKey:
+      '-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg\n-----END PRIVATE KEY-----',
+  },
+  storekit: { bundleId: 'com.example.app', environment: 'Sandbox' },
+  readOnly: false,
+  confirmWrites: 'off',
+  includeDeprecated: false,
+  dryRun: false,
+};
+
+/**
+ * The point of MIL-218 is that a decoded field is only worth more than the
+ * envelope if its signature was checked. These pin the two halves of that: no
+ * roots means no decoding, and a payload that fails verification produces an
+ * error rather than fields with a caveat attached.
+ */
+describe('StoreKit payload verification', () => {
+  it('hands back the envelope when no roots are configured', async () => {
+    const service = new StoreKitService(base);
+    const decoded = await (service as any).decode(['a.b.c'], 'Sandbox', false);
+    expect(decoded).toEqual(['a.b.c']);
+  });
+
+  it('hands back the envelope when the caller asks for raw, even with roots', async () => {
+    const service = new StoreKitService({
+      ...base,
+      storekit: { ...base.storekit!, appleRootCerts: ['/nope/missing.cer'] },
+    });
+    const decoded = await (service as any).decode(['a.b.c'], 'Sandbox', true);
+    expect(decoded).toEqual(['a.b.c']);
+  });
+
+  // A path that does not exist reads as "no roots" rather than crashing the
+  // server: 24 other tools do not need them.
+  it('treats an unreadable certificate path as no roots at all', () => {
+    const service = new StoreKitService({
+      ...base,
+      storekit: { ...base.storekit!, appleRootCerts: ['/nope/missing.cer'] },
+    });
+    expect((service as any).canVerify).toBe(false);
+  });
+
+  // A misconfigured root used to surface as a raw OpenSSL string — "PEM
+  // routines::no start line" — which says nothing about what to do next.
+  it('says what is wrong when the roots do not parse', async () => {
+    const service = new StoreKitService({
+      ...base,
+      storekit: { ...base.storekit!, appleRootCerts: [] },
+    });
+    // Force a verifier with a bogus root so verification is attempted and fails.
+    (service as any).rootCertificates = [Buffer.from('not a certificate')];
+    await expect((service as any).decode(['a.b.c'], 'Sandbox', false)).rejects.toThrow(
+      /does not parse as Apple's DER root certificates/
+    );
+  });
+});


### PR DESCRIPTION
Closes MIL-218.

`storekit__get_transaction_info` and the two history tools returned Apple's signed envelope because the alternative on offer was worse: `jwsClaim` base64-decodes **without checking the signature**, and presenting unverified data as fact is not an improvement on handing back the JWS.

Set `ASC_APPLE_ROOT_CERTS` — paths, or one directory — and those three verify each payload with the App Store Server Library and return decoded fields. Leave it unset and they behave exactly as before. Every response states which one it gave (`verified: true|false`), so a caller never has to infer it.

## Three decisions worth naming

**Nothing is decoded without being checked.** A verification failure is an error, not fields with a caveat attached. The point of verifying is that the result can be treated as fact; *"here are the values, but we could not confirm them"* invites the reading it was meant to prevent.

**The decoded shape is an allowlist**, not Apple's whole payload. `appAccountToken` is left out deliberately — it is the UUID a developer maps to their own user record, so a transaction id becomes a route back to an account inside their app, and none of these tools was asked for that. `raw: true` returns the signed payload for callers who verify themselves.

**No certificates ship here.** They are Apple's to publish and one more thing to keep current; a stale one turns verification into a silent no. Unset is a supported state rather than a broken one.

Online revocation checks are off: they add a network call per payload whose outage is indistinguishable from a verification failure, and the roots already pin the chain.

## What the tests caught

A file that is not a DER certificate failed inside OpenSSL with `error:0480006C:PEM routines::no start line` — a message nobody can act on. Verifier construction is wrapped now and names both the variable and the fix.

Four new tests pin the contract from both ends: no roots means no decoding, `raw` wins even with roots configured, an unreadable path reads as "no roots" rather than crashing a server whose other 24 tools do not need them, and a root that does not parse says so.

508 passing.