### PR TITLE
fix: make --include-deprecated do something in profile mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. The format is based on 
 ## English
 ### [Unreleased]
 
+#### `--include-deprecated` does something in profile mode
+It was a no-op there and said nothing about it. Profile membership is hand-curated in `spec/profiles.csv` and nobody curates an endpoint Apple has retired, so **0 of the 123** deprecated operations were reachable from any profile — the flag only ever worked on the no-profile server with `--domains`.
+
+Passing it now adds the retired operations of the domains the profile covers. Measured: `game-center` goes 184 tools to 298, `monetization` 199 to 208. Membership is by domain rather than by curation, which is the honest definition rather than a shortcut — "everything retired in the areas this profile covers" is what someone passing this flag is asking for, and there is no curated answer to inherit.
+
+
 #### StoreKit reads can return verified fields instead of a sealed envelope
 Set `ASC_APPLE_ROOT_CERTS` to Apple's DER root certificates — paths, or one directory — and `storekit__get_transaction_info`, `storekit__get_transaction_history` and `storekit__get_refund_history` verify each payload with the App Store Server Library and return decoded fields. Leave it unset and they return the signed payloads exactly as before, which is what their descriptions already promised. Every response says which one it is, so a caller never has to infer it.
 
@@ -265,6 +271,12 @@ Safety and usability release: every write is now schema-checked locally, preview
 
 ## Türkçe
 ### [Unreleased]
+
+#### `--include-deprecated` profil modunda bir şey yapıyor
+Orada hiçbir şey yapmıyordu ve bunu da söylemiyordu. Profil üyeliği `spec/profiles.csv`'de elle küratörlükten geçiyor ve Apple'ın emekli ettiği bir endpoint'i kimse küratörlükten geçirmiyor; yani 123 deprecated işlemin **sıfırı** hiçbir profilden erişilebilir değildi. Bayrak yalnızca profilsiz sunucuda `--domains` ile çalışıyordu.
+
+Artık bayrağı verince, profilin kapsadığı domain'lerdeki emekli işlemler ekleniyor. Ölçüldü: `game-center` 184 araçtan 298'e, `monetization` 199'dan 208'e çıkıyor. Üyelik küratörlükle değil domain'le belirleniyor; bu bir kestirme değil dürüst tanım — bu bayrağı veren kişinin istediği şey "bu profilin kapsadığı alanlarda emekli olan her şey" ve devralınacak küratörlü bir cevap yok.
+
 
 #### StoreKit okumaları mühürlü zarf yerine doğrulanmış alan döndürebiliyor
 `ASC_APPLE_ROOT_CERTS`'i Apple'ın DER kök sertifikalarına ayarlayın — dosya yolları ya da tek bir dizin — ve `storekit__get_transaction_info`, `storekit__get_transaction_history`, `storekit__get_refund_history` her yükü App Store Server Library ile doğrulayıp çözülmüş alanlar döndürsün. Ayarlamazsanız eskisi gibi imzalı yükleri döndürüyorlar; açıklamalarının zaten vaat ettiği şey de bu. Her cevap hangisi olduğunu söylüyor, çağıranın tahmin etmesi gerekmiyor.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -241,7 +241,7 @@ The App Store Server API answers questions about individual customers rather tha
 | `--confirm` | Ask before every write, not just the strong risk levels |
 | `--no-confirm` | Never ask; the client's own tool approval is the only gate |
 | `--dry-run` | Writes never reach Apple; each mutating call returns what would have been sent, with its risk level |
-| `--include-deprecated` | Also load the 123 operations Apple has deprecated |
+| `--include-deprecated` | Also load the 123 operations Apple has deprecated. In profile mode this adds the retired operations of the domains that profile covers — 102 of the 123 are Game Center |
 
 > [!TIP]
 > **Confirm before risky writes (on by default).** Before a `revenue`, `destructive`, `infrastructure` or `access` write runs — changing a price, handing out Admin, deleting a certificate — Heimdall asks you to confirm through your client's prompt ([MCP elicitation](https://modelcontextprotocol.io/)), showing what would change. So even if the assistant misreads "drop the price a bit" as `0.99`, nothing changes until you approve it. Everything below those levels runs on your client's own tool approval.
@@ -587,7 +587,7 @@ App Store Server API, listeniz hakkında değil tek tek müşteriler hakkında s
 | `--confirm` | Yalnızca güçlü risk seviyelerinde değil, her yazmadan önce sor |
 | `--no-confirm` | Hiç sorma; tek kapı client'ın kendi araç onayı olur |
 | `--dry-run` | Yazmalar Apple'a gitmez; her mutasyon çağrısı gönderilecek olanı risk seviyesiyle döndürür |
-| `--include-deprecated` | Apple'ın kullanımdan kaldırdığı 123 işlemi de yükle |
+| `--include-deprecated` | Apple'ın kullanımdan kaldırdığı 123 işlemi de yükle. Profil modunda, o profilin kapsadığı domain'lerdeki emekli işlemleri ekler — 123'ün 102'si Game Center |
 
 > [!TIP]
 > **Riskli yazmalardan önce onay (varsayılan açık).** Bir `revenue`, `destructive`, `infrastructure` ya da `access` yazması çalışmadan önce — fiyat değiştirme, Admin yetkisi verme, sertifika silme — Heimdall client'ınızın istemi üzerinden ([MCP elicitation](https://modelcontextprotocol.io/)) onay ister ve neyin değişeceğini gösterir. Yani asistan "fiyatı biraz düşür"ü yanlışlıkla `0.99` olarak anlasa bile, siz onaylamadan hiçbir şey değişmez. Bu seviyelerin altındaki her şey client'ınızın kendi araç onayıyla çalışır.

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -11,6 +11,7 @@
  * eleven profiles could not reach their own resources from an app.
  */
 import { CORE, PROFILE_DATA, type GeneratedSubProfile } from './generated/profiles-data.js';
+import { OPERATIONS } from './generated/operations.js';
 
 export interface SubProfile extends GeneratedSubProfile {
   description: string;
@@ -208,6 +209,29 @@ export function resolveSelection(spec: string): ProfileSelection {
 /** Every spec operation a selection serves, core included. */
 export function operationsFor(selection: ProfileSelection): string[] {
   return [...new Set([...CORE_OPERATIONS, ...selection.subProfiles.flatMap((s) => s.operations)])];
+}
+
+/**
+ * The deprecated operations `--include-deprecated` should add to a selection.
+ *
+ * They are in no profile: membership is hand-curated in spec/profiles.csv and
+ * nobody curates an endpoint Apple has retired, so 0 of 123 were reachable in
+ * profile mode and the flag silently did nothing there — it only ever worked on
+ * the no-profile server with `--domains`.
+ *
+ * Membership by DOMAIN rather than by curation, and that is the honest
+ * definition rather than a shortcut: "everything retired in the areas this
+ * profile covers" is what someone passing this flag is asking for, and there is
+ * no curated answer to inherit. Most of it is Game Center — 102 of the 123 —
+ * so `game-center --include-deprecated` is the case this visibly changes.
+ */
+export function deprecatedOperationsFor(selection: ProfileSelection): string[] {
+  const domains = new Set(
+    operationsFor(selection)
+      .map((name) => OPERATIONS.find((op) => op.name === name)?.domain)
+      .filter(Boolean) as string[]
+  );
+  return OPERATIONS.filter((op) => op.deprecated && domains.has(op.domain)).map((op) => op.name);
 }
 
 /** Hand-written tools a selection serves (StoreKit, reviews-AI, pricing macros). */

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ import { STRONG_CONFIRM_LEVELS, type RiskLevel } from './core/risk.js';
 import {
   CORE_OPERATIONS,
   manualToolsFor,
+  deprecatedOperationsFor,
   operationsFor,
   profilesForOperation,
   registerCommand,
@@ -136,7 +137,14 @@ export function createServer(config: ServerConfig, selection?: ProfileSelection)
   const registry = new ToolRegistry({
     // A profile carries an explicit, hand-curated list; core (apps.list/get and
     // the four shared relationship listings) is already folded into it.
-    operations: selection ? operationsFor(selection) : undefined,
+    operations: selection
+      ? [
+          ...operationsFor(selection),
+          // Deprecated operations are in no profile, so without this the flag
+          // was a no-op in profile mode — see deprecatedOperationsFor.
+          ...(config.includeDeprecated ? deprecatedOperationsFor(selection) : []),
+        ]
+      : undefined,
     domains: selection ? undefined : config.domains,
     readOnly: config.readOnly,
     includeDeprecated: config.includeDeprecated,

--- a/tests/profile-invariants.test.ts
+++ b/tests/profile-invariants.test.ts
@@ -12,6 +12,7 @@ import {
   CORE_MANUAL_TOOLS,
   REMOVED_PROFILES,
   descriptionKey,
+  deprecatedOperationsFor,
   manualToolsFor,
   operationsFor,
   removedProfileMessage,
@@ -275,5 +276,37 @@ describe('server.json stays in step with the profiles', () => {
 
     expect(count(narrow), 'narrow count in server.json').toBe(Number(claimedNarrow));
     expect(count(wide), 'wide count in server.json').toBe(Number(claimedWide));
+  });
+});
+
+/**
+ * `--include-deprecated` was a no-op in profile mode and said nothing about it.
+ * Membership is hand-curated in spec/profiles.csv and nobody curates an
+ * endpoint Apple has retired, so 0 of the 123 deprecated operations were
+ * reachable from any profile — the flag only ever worked on the no-profile
+ * server with `--domains`.
+ */
+describe('--include-deprecated in profile mode', () => {
+  const selection = resolveSelection('game-center');
+
+  it('adds nothing on its own — the curated set has no deprecated operations', () => {
+    const curated = operationsFor(selection);
+    const deprecated = new Set(OPERATIONS.filter((op) => op.deprecated).map((op) => op.name));
+    expect(curated.filter((name) => deprecated.has(name))).toEqual([]);
+  });
+
+  it('offers the retired operations of the domains the profile covers', () => {
+    const extra = deprecatedOperationsFor(selection);
+    expect(extra.length).toBeGreaterThan(0);
+    // Every one is genuinely deprecated, and genuinely in scope for this
+    // profile — the definition is by domain, since there is no curated answer.
+    const byName = new Map(OPERATIONS.map((op) => [op.name, op]));
+    const domains = new Set(
+      operationsFor(selection).map((n) => byName.get(n)?.domain).filter(Boolean)
+    );
+    for (const name of extra) {
+      expect(byName.get(name)?.deprecated, `${name} is not deprecated`).toBe(true);
+      expect(domains.has(byName.get(name)?.domain), `${name} is out of scope`).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Closes MIL-215.

The flag was a no-op in profile mode and said nothing about it. Profile membership is hand-curated in `spec/profiles.csv`, and nobody curates an endpoint Apple has retired, so **0 of the 123** deprecated operations were reachable from any profile. It only ever worked on the no-profile server with `--domains`.

## After

Passing it adds the retired operations of the domains the profile covers, measured through a real `tools/list`:

```
game-center                 184 -> 298
monetization                199 -> 208
```

102 of the 123 are Game Center, which is why that profile is where this is visible.

## Why by domain

Membership is by domain rather than by curation, and that is the honest definition rather than a shortcut: *"everything retired in the areas this profile covers"* is what someone passing this flag is asking for, and there is no curated answer to inherit — nobody was ever going to hand-place 123 dead endpoints into thirteen profiles.

## Tests

Two, holding it from both ends: the curated set still contains no deprecated operation (so the flag is what adds them, not a leak), and everything the flag adds is both genuinely deprecated and genuinely inside one of the profile's domains.

510 passing.