### PR TITLE
fix: count the tools the client will receive, not the ones the profile maps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project are documented here. The format is based on 
 ## English
 ### [Unreleased]
 
+#### The startup banner counts what the client will actually receive
+`asc-monetization (206 tools)` and a client showing 199 was the same server disagreeing with itself. The banner quoted the operations the profile *maps*; `tools/list` answers with what is served, and those differ by configuration — `asc__call` and `asc__describe` are always there and mapped nowhere, StoreKit only loads with a bundle id, `--read-only` removes the writes, and since this release `--include-deprecated` adds tools too.
+
+Both now come from one list, so they cannot drift: the count is the length of the array the handler returns. `asc__status`'s token estimate follows it for the same reason — it exists to answer "what is this costing my context", which is a question about what was loaded.
+
+The catalogue number is unchanged and still means what it says: 883 tools across 13 profiles, in the README, `server.json` and `CITATION.cff`, cross-checked by the release pre-flight.
+
+
 #### `--include-deprecated` does something in profile mode
 It was a no-op there and said nothing about it. Profile membership is hand-curated in `spec/profiles.csv` and nobody curates an endpoint Apple has retired, so **0 of the 123** deprecated operations were reachable from any profile — the flag only ever worked on the no-profile server with `--domains`.
 
@@ -271,6 +279,14 @@ Safety and usability release: every write is now schema-checked locally, preview
 
 ## Türkçe
 ### [Unreleased]
+
+#### Açılış banner'ı istemcinin gerçekten alacağı sayıyı yazıyor
+`asc-monetization (206 tools)` yazıp istemcide 199 görünmesi, sunucunun kendisiyle çelişmesiydi. Banner profilin *eşlediği* işlem sayısını söylüyordu; `tools/list` ise servis edileni döndürüyor ve ikisi yapılandırmaya göre ayrışıyor — `asc__call` ile `asc__describe` her zaman var ve hiçbir yere eşlenmemiş, StoreKit yalnızca bundle ID ile yükleniyor, `--read-only` yazmaları kaldırıyor, bu sürümden itibaren `--include-deprecated` de araç ekliyor.
+
+Artık ikisi tek bir listeden geliyor, yani ayrışamazlar: sayı, handler'ın döndürdüğü dizinin uzunluğu. `asc__status`'un token tahmini de aynı sebeple onu izliyor — "bu benim bağlamıma neye mal oluyor" sorusunun cevabı, yüklenen şeyle ilgili bir soru.
+
+Katalog sayısı değişmedi ve söylediği şeyi söylemeye devam ediyor: 13 profilde 883 araç — README, `server.json` ve `CITATION.cff`'te, yayın öncesi kontrolüyle çapraz doğrulanıyor.
+
 
 #### `--include-deprecated` profil modunda bir şey yapıyor
 Orada hiçbir şey yapmıyordu ve bunu da söylemiyordu. Profil üyeliği `spec/profiles.csv`'de elle küratörlükten geçiyor ve Apple'ın emekli ettiği bir endpoint'i kimse küratörlükten geçirmiyor; yani 123 deprecated işlemin **sıfırı** hiçbir profilden erişilebilir değildi. Bayrak yalnızca profilsiz sunucuda `--domains` ile çalışıyordu.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,12 @@ import { pathToFileURL } from 'node:url';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { loadConfig } from './core/config.js';
 import { ConfigError } from './core/errors.js';
-import { createServer, createRemovedProfileServer, VERSION } from './server.js';
+import {
+  createServer,
+  createRemovedProfileServer,
+  servedToolCount,
+  VERSION,
+} from './server.js';
 import { ALL_DOMAINS, DEFAULT_DOMAINS } from './core/registry.js';
 import { OPERATIONS, SPEC_VERSION } from './generated/operations.js';
 import { PROFILES, REMOVED_PROFILES, resolveSelection, toolCountFor } from './profiles.js';
@@ -158,10 +163,16 @@ async function main(): Promise<void> {
   await server.connect(transport);
 
   // stderr is safe: stdout carries the MCP protocol itself.
+  //
+  // The count is what tools/list will actually answer, not what the profile
+  // maps. Those differ by configuration — StoreKit needs a bundle id,
+  // --read-only removes writes, --include-deprecated adds tools — and quoting
+  // the mapped number meant every client showed something else.
+  const served = servedToolCount(server);
   const scope = selection
     ? `asc-${selection.profile.name}` +
       (selection.partial ? `:${selection.subProfiles.map((s) => s.name).join(',')}` : '') +
-      ` (${toolCountFor(selection)} tools)`
+      ` (${served ?? toolCountFor(selection)} tools)`
     : 'asc-mcp';
   console.error(
     `${scope} v${VERSION} ready (spec ${SPEC_VERSION}${config.readOnly ? ', read-only' : ''})`

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,6 +103,20 @@ export const SERVER_INSTRUCTIONS = [
   '   app → group → subscription → price chain. Prefer it over walking the chain.',
 ].join('\n');
 
+/**
+ * How many tools each server actually serves, by server.
+ *
+ * A WeakMap rather than a field on the SDK's `Server`: the count has to be read
+ * from outside (index.ts prints the banner) without changing the type every
+ * call site depends on, and it must not keep a server alive.
+ */
+const toolCounts = new WeakMap<Server, () => number>();
+
+/** What `tools/list` will return for this server — the number a client sees. */
+export function servedToolCount(server: Server): number | undefined {
+  return toolCounts.get(server)?.();
+}
+
 export function createServer(config: ServerConfig, selection?: ProfileSelection): Server {
   const tokens = new TokenProvider(config.credentials);
   // ASC_BASE_URL redirects everything to a local fixture server for testing;
@@ -180,7 +194,9 @@ export function createServer(config: ServerConfig, selection?: ProfileSelection)
             loaded: loadedSubs.has(s),
             description: s.description,
           })),
-        estimatedTokens: toolCountFor(selection) * TOKENS_PER_TOOL,
+        // What this server actually serves, not what the profile maps: the
+        // estimate exists to answer "what is this costing my context".
+        estimatedTokens: (servedToolCount(server) ?? toolCountFor(selection)) * TOKENS_PER_TOOL,
         ...(unloadedSubs().length
           ? {
               hint:
@@ -382,7 +398,18 @@ export function createServer(config: ServerConfig, selection?: ProfileSelection)
     );
   };
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
+  /**
+   * Exactly what `tools/list` answers.
+   *
+   * Named rather than inlined so the startup banner can count the same list the
+   * client receives. It used to quote `toolCountFor`, which counts the
+   * operations the profile MAPS — a number that is stable, easy to put in a
+   * changelog, and wrong in every client: `asc__call` and `asc__describe` are
+   * always served and mapped nowhere, StoreKit only loads with a bundle id, and
+   * since #66 `--include-deprecated` adds tools too. Someone reading "24" and
+   * seeing 29 has no way to tell whether they misconfigured something.
+   */
+  const servedTools = (): McpToolDefinition[] => {
     const onDemand = loadTool();
     const tools: McpToolDefinition[] = [
       ...META_TOOLS,
@@ -400,8 +427,12 @@ export function createServer(config: ServerConfig, selection?: ProfileSelection)
       tools.push(...storekitTools);
     }
 
-    return { tools };
-  });
+    return tools;
+  };
+
+  toolCounts.set(server, () => servedTools().length);
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: servedTools() }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     let name = request.params.name;

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -15,9 +15,9 @@
 import { describe, it, expect } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createServer, formatError } from '../src/server.js';
+import { createServer, formatError, servedToolCount } from '../src/server.js';
 import { AscApiError } from '../src/core/errors.js';
-import { resolveSelection } from '../src/profiles.js';
+import { resolveSelection, toolCountFor } from '../src/profiles.js';
 import type { ServerConfig } from '../src/core/config.js';
 
 const config: ServerConfig = {
@@ -160,5 +160,29 @@ describe('what a failure tells the caller', () => {
   it('leaves a local refusal as the prose it was written as', () => {
     const text = formatError(new AscApiError('Loaded read-only. Use asc__load.', 0), 'asc__call');
     expect(text).toBe('asc__call failed: Loaded read-only. Use asc__load.');
+  });
+});
+
+/**
+ * MIL-214: the startup banner quoted the operations a profile MAPS while the
+ * client received a different number, and someone reading "24" against 29 in
+ * their client had no way to tell whether they had misconfigured something.
+ * The two have to agree by construction, not by anyone remembering to update a
+ * count when a tool moves.
+ */
+describe('the count a client sees', () => {
+  it('matches what tools/list returns, including the always-served proxy tools', async () => {
+    const selection = resolveSelection('monetization:subscription-catalog');
+    const server = createServer(config, selection);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'test', version: '0' }, { capabilities: {} });
+    await Promise.all([server.connect(st), client.connect(ct)]);
+
+    const listed = (await client.listTools()).tools.length;
+    expect(servedToolCount(server)).toBe(listed);
+
+    // And it is genuinely a different number from the mapped one — otherwise
+    // this test would pass with the bug still in place.
+    expect(listed).not.toBe(toolCountFor(selection));
   });
 });


### PR DESCRIPTION
Closes MIL-214.

`asc-monetization (206 tools)` against 199 in the client was the server disagreeing with itself. The banner quoted `toolCountFor` — the operations a profile *maps* — while `tools/list` answers with what is served.

They differ by configuration: `asc__call` and `asc__describe` are always served and mapped nowhere, StoreKit only loads with a bundle id, `--read-only` removes the writes, and since #66 `--include-deprecated` adds tools. The sign of the difference was not even consistent, so nobody could learn a rule for it.

```
                                     banner   served
monetization:subscription-pricing        24       29
app-info                                 57       59
monetization                            206      199
```

## After

Both numbers come from one list — `servedTools()` is what the handler returns and what the banner counts — so they cannot drift again. Verified against a real `tools/list` in the same environment:

```
asc-monetization (208 tools)              tools/list: 208
asc-app-info (59 tools)                   tools/list: 59
asc-monetization --read-only (115 tools)  tools/list: 115
```

The count travels in a `WeakMap` keyed by server rather than as a field on the SDK's `Server`: every call site depends on that type and none of them wants a count.

`asc__status`'s token estimate follows the same number — it exists to answer *"what is this costing my context"*, which is a question about what loaded.

## Not changed

The advertised catalogue number. 883 across 13 profiles is a claim about the catalogue, it belongs in the README, `server.json` and `CITATION.cff`, and the release pre-flight already cross-checks all three.

A test pins the agreement and also asserts the served count differs from the mapped one — otherwise it would pass with the bug still in place. 510 passing.