### PR TITLE
ci: test three platforms, the packed tarball, and the protocol contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,25 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Three operating systems because the failures differ by platform and none
+    # of them show up on the author's machine: Windows disagrees about path
+    # separators and quoting, macOS is the only one with a Keychain, and Ubuntu
+    # is what CI and most users' containers actually run.
+    #
+    # The full Node matrix runs on Ubuntu; the other two run one version each.
+    # Nine jobs to catch a platform bug that one job per platform already
+    # catches is paying for a matrix rather than a signal.
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         node: ['20', '22', '24']
+        include:
+          - os: macos-latest
+            node: '24'
+          - os: windows-latest
+            node: '24'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -70,6 +85,79 @@ jobs:
           }, 2500);
           "
 
+  # What `npm ci` in this checkout cannot tell you: whether the tarball npm
+  # actually publishes works. `files` decides what ships, and a path left out of
+  # it fails nowhere until someone installs the package — the listing macros
+  # shipped unreachable in 2.0.0 for a neighbouring reason. So: pack, install
+  # into a directory that has none of this repository, and run the binary.
+  pack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
+      - name: Install the packed tarball into a clean directory
+        run: |
+          set -euo pipefail
+          TARBALL="$(npm pack --silent)"
+          mkdir -p /tmp/packtest
+          mv "$TARBALL" /tmp/packtest/
+          cd /tmp/packtest
+          npm init -y >/dev/null
+          npm install --silent "./$TARBALL"
+
+      - name: The installed binary answers for itself
+        run: |
+          set -euo pipefail
+          cd /tmp/packtest
+          BIN=node_modules/.bin/asc-mcp
+          test -x "$BIN" || { echo "no executable at $BIN — check the bin field"; exit 1; }
+          "$BIN" --version
+          "$BIN" --help | grep -q 'Profiles:' || { echo "--help lost its profile list"; exit 1; }
+
+      # Booting is the part that catches a missing file: --help reads no
+      # generated output, while starting a profile loads the catalogue, the
+      # profile data and the macros.
+      - name: The installed server starts and serves a profile
+        run: |
+          set -euo pipefail
+          cd /tmp/packtest
+          node -e "
+          const { generateKeyPairSync } = require('crypto');
+          const { privateKey } = generateKeyPairSync('ec', {
+            namedCurve: 'P-256',
+            privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+            publicKeyEncoding: { type: 'spki', format: 'pem' },
+          });
+          require('fs').writeFileSync('/tmp/pack.p8', privateKey);
+          "
+          ASC_KEY_ID=CI0000000 \
+          ASC_ISSUER_ID=00000000-0000-0000-0000-000000000000 \
+          ASC_PRIVATE_KEY_PATH=/tmp/pack.p8 \
+          node -e "
+          const { spawn } = require('child_process');
+          const p = spawn('node_modules/.bin/asc-mcp', ['app-info'], { env: process.env });
+          let out = '';
+          p.stdout.on('data', d => out += d);
+          p.stdin.write(JSON.stringify({jsonrpc:'2.0',id:1,method:'initialize',params:{protocolVersion:'2024-11-05',capabilities:{},clientInfo:{name:'pack',version:'1'}}}) + '\n');
+          setTimeout(() => {
+            p.stdin.write(JSON.stringify({jsonrpc:'2.0',method:'notifications/initialized'}) + '\n');
+            p.stdin.write(JSON.stringify({jsonrpc:'2.0',id:2,method:'tools/list'}) + '\n');
+          }, 500);
+          setTimeout(() => {
+            p.kill();
+            const listed = out.split('\n').filter(Boolean).map(l => { try { return JSON.parse(l); } catch { return null; } }).find(r => r && r.id === 2);
+            const count = listed?.result?.tools?.length ?? 0;
+            console.log('Tools served from the packed install:', count);
+            process.exit(count > 40 ? 0 : 1);
+          }, 3000);
+          "
+
   # Flags dependencies a pull request would newly introduce that carry known
   # advisories or an incompatible licence, before they reach the lockfile.
   dependency-review:
@@ -85,7 +173,7 @@ jobs:
   # without the ruleset going stale.
   ci-ok:
     if: always()
-    needs: [test, smoke, dependency-review]
+    needs: [test, smoke, pack, dependency-review]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if a required job did not succeed

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -192,17 +192,42 @@ export const OTHER_CLIENT: McpClient = { id: 'other', label: 'Other / not listed
  * Walks PATH rather than shelling out to `which`: no subprocess per client on
  * every setup run, and no `shell: true`, which Node now warns about because the
  * arguments are concatenated rather than escaped.
+ *
+ * Windows needs both halves of this spelled out. Executables there are
+ * `claude.cmd` or `claude.exe`, never bare `claude`, so looking for the plain
+ * name found nothing — every CLI client read as absent and `register` reported
+ * success having written nothing. And `X_OK` is not meaningful on Windows:
+ * `accessSync` accepts it and answers about readability, so it was never the
+ * part doing the work anyway.
+ *
+ * Found by putting the suite on a Windows runner, where three registration
+ * tests failed with an empty call list.
  */
-const hasBinary = (bin: string): boolean =>
-  (process.env.PATH ?? '').split(delimiter).some((d) => {
+const hasBinary = (bin: string): boolean => {
+  const windows = process.platform === 'win32';
+  const names = windows
+    ? [
+        bin,
+        ...(process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
+          .split(';')
+          .filter(Boolean)
+          .map((ext) => bin + ext.toLowerCase()),
+      ]
+    : [bin];
+  const mode = windows ? constants.F_OK : constants.X_OK;
+
+  return (process.env.PATH ?? '').split(delimiter).some((d) => {
     if (!d) return false;
-    try {
-      accessSync(join(d, bin), constants.X_OK);
-      return true;
-    } catch {
-      return false;
-    }
+    return names.some((name) => {
+      try {
+        accessSync(join(d, name), mode);
+        return true;
+      } catch {
+        return false;
+      }
+    });
   });
+};
 
 /** An app bundle, in either place macOS puts them. */
 const hasApp = (name: string): boolean =>

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Protocol conformance — the shape of what a client receives, not what any one
+ * tool does.
+ *
+ * Everything else in this directory tests behaviour through a client that we
+ * also wrote. These assert the contract the SDK and the MCP specification
+ * impose, which is the half a passing suite can hide: a tool name that a strict
+ * client rejects, a missing inputSchema, an unknown tool answered as a protocol
+ * error instead of a tool error. None of it fails loudly in development,
+ * because our own client is forgiving.
+ */
+import { describe, it, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../src/server.js';
+import { resolveSelection } from '../src/profiles.js';
+import type { ServerConfig } from '../src/core/config.js';
+
+const config: ServerConfig = {
+  credentials: { keyId: 'TESTKEY123', issuerId: 'issuer', privateKey: 'not-used-here' },
+  readOnly: false,
+  confirmWrites: 'off',
+  includeDeprecated: false,
+  dryRun: true,
+};
+
+async function connect(spec?: string, overrides: Partial<ServerConfig> = {}) {
+  const server = createServer({ ...config, ...overrides }, spec ? resolveSelection(spec) : undefined);
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'conformance', version: '0' }, { capabilities: {} });
+  await Promise.all([server.connect(st), client.connect(ct)]);
+  return client;
+}
+
+describe('what a client receives', () => {
+  it('advertises the tools capability and identifies itself', async () => {
+    const client = await connect('app-info');
+    expect(client.getServerCapabilities()?.tools).toBeDefined();
+    const info = client.getServerVersion();
+    expect(info?.name).toBe('asc-app-info');
+    // A version a client can report back is how a bug lands with a number
+    // attached instead of "the App Store one".
+    expect(info?.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  /**
+   * MCP pins tool names to ^[a-zA-Z0-9_-]{1,128}$. Apple's operation ids are
+   * dotted, so every name here is encoded on the way out — and a client that
+   * enforces the pattern drops the whole list rather than the one bad entry.
+   */
+  it('gives every tool a name the specification allows', async () => {
+    const client = await connect('monetization');
+    const bad = (await client.listTools()).tools
+      .map((t) => t.name)
+      .filter((n) => !/^[a-zA-Z0-9_-]{1,128}$/.test(n));
+    expect(bad).toEqual([]);
+  });
+
+  it('gives every tool a description and an object input schema', async () => {
+    const client = await connect('monetization');
+    const wrong = (await client.listTools()).tools
+      .filter((t) => !t.description || t.inputSchema?.type !== 'object')
+      .map((t) => t.name);
+    expect(wrong).toEqual([]);
+  });
+
+  /**
+   * A tool that fails is a RESULT with isError, not a JSON-RPC error. The
+   * difference matters: a protocol error aborts the client's turn, while a tool
+   * error is something the model can read and route around.
+   */
+  it('answers an unknown tool as a tool error, not a protocol error', async () => {
+    const client = await connect('app-info');
+    const res: any = await client.callTool({ name: 'asc__call', arguments: { tool: 'nope__nope' } });
+    expect(res.isError).toBe(true);
+    expect(String(res.content?.[0]?.text ?? '')).toMatch(/nope__nope|not a tool|Unknown/i);
+  });
+
+  it('hides every mutating tool under --read-only rather than refusing it later', async () => {
+    const client = await connect('monetization', { readOnly: true });
+    const mutating = (await client.listTools()).tools.filter(
+      (t) => t.annotations?.readOnlyHint === false
+    );
+    expect(mutating.map((t) => t.name)).toEqual([]);
+  });
+
+  it('serves the same list twice — nothing is consumed by being listed', async () => {
+    const client = await connect('app-info');
+    const first = (await client.listTools()).tools.map((t) => t.name).sort();
+    const second = (await client.listTools()).tools.map((t) => t.name).sort();
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -35,7 +35,9 @@ describe('skill installation', () => {
 
     const path = skillPathFor('claude', home)!;
     expect(path).toBe(join(home, '.claude', 'skills', 'heimdall', 'SKILL.md'));
-    const text = readFileSync(path, 'utf8');
+    // Normalised for the same reason as the frontmatter checks below: the file
+    // is copied byte for byte, so on a Windows checkout it arrives with CRLF.
+    const text = readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
     expect(text.startsWith('---\nname: heimdall\n')).toBe(true);
     // The one claim the skill exists to make; losing it would leave a document
     // that costs tokens and changes nothing.
@@ -92,7 +94,9 @@ describe('the packaged skill is loadable as a plugin', () => {
   const SKILL_FILES = ['skills/heimdall/SKILL.md', '.claude/skills/heimdall-contrib/SKILL.md'];
 
   it.each(SKILL_FILES)('keeps %s frontmatter to fields the loader accepts', (file) => {
-    const text = readFileSync(file, 'utf8');
+    // Normalised: Windows checks out with CRLF, and `^---\n` then matches
+    // nothing — the frontmatter reads as absent rather than as malformed.
+    const text = readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
     const frontmatter = /^---\n([\s\S]*?)\n---/.exec(text)![1];
     const keys = frontmatter
       .split('\n')
@@ -110,7 +114,9 @@ describe('the packaged skill is loadable as a plugin', () => {
   // this pins the cheaper rule — no `: ` in an unquoted value at all — because
   // the descriptions are long English prose and a colon is easy to reach for.
   it.each(SKILL_FILES)('keeps ": " out of %s unquoted frontmatter values', (file) => {
-    const text = readFileSync(file, 'utf8');
+    // Normalised: Windows checks out with CRLF, and `^---\n` then matches
+    // nothing — the frontmatter reads as absent rather than as malformed.
+    const text = readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
     const frontmatter = /^---\n([\s\S]*?)\n---/.exec(text)![1];
     for (const line of frontmatter.split('\n')) {
       const value = /^[a-z-]+: (.*)$/.exec(line)?.[1];


### PR DESCRIPTION
Three of the four parts of MIL-195. The fourth is argued against at the bottom.

## OS matrix

The failures differ by platform and none of them show up on the author's machine: Windows disagrees about path separators and quoting, macOS is the only one with a Keychain, Ubuntu is what CI and most containers run.

The full Node matrix stays on Ubuntu; macOS and Windows run one version each. Nine jobs to catch a platform bug that three already catch is paying for a matrix rather than a signal.

**This PR is where we find out whether the suite passes on Windows.** If it does not, that is the finding.

## Pack test

`npm ci` in this checkout cannot tell you whether the tarball npm publishes works. `files` decides what ships, and a path left out of it fails nowhere until someone installs the package — the listing macros shipped unreachable in 2.0.0 for a neighbouring reason.

So: pack, install into a directory that has none of this repository, run `--version` and `--help`, then **boot a profile**. Booting is the part that catches a missing file, since `--help` reads no generated output while starting a profile loads the catalogue, the profile data and the macros.

Rehearsed locally end to end: `Tools served from the packed install: 59`.

## Conformance tests

Every other test here drives a client we also wrote, and ours is forgiving in exactly the places a strict client is not. Six assertions about the contract rather than the behaviour:

- every tool name matches MCP's `^[a-zA-Z0-9_-]{1,128}$` — Apple's ids are dotted, and a client that enforces the pattern drops the whole list rather than one entry
- every tool carries a description and an object input schema
- an unknown tool comes back as a **tool** error, not a protocol error — that difference decides whether the client's turn continues or aborts
- `--read-only` hides mutating tools rather than refusing them after they are called
- the server advertises the tools capability and a parseable version
- listing twice returns the same list

## Not done: the linter

Adding one to a repository that has never had one is a diff of hundreds of mechanical edits landing on top of a day of real changes, and what it buys here is style consistency in a codebase with one author. It deserves its own pass when nothing else is in flight, not a paragraph in this one.

517 tests passing locally.