### PR TITLE
chore: regenerate from Apple's specification, which moved without a version bump

### DIFF
--- a/src/generated/REPORT.txt
+++ b/src/generated/REPORT.txt
@@ -6,7 +6,7 @@ Tools:          982
   mutating:     466
   deprecated:   123
 Risk levels:    low:173 destructive:110 revenue:88 public:60 infrastructure:16 release:13 access:6
-Body schemas:   334 (298 KB resolved, avg 914 chars)
+Body schemas:   334 (297 KB resolved, avg 911 chars)
 
 By domain:
   game_center          273

--- a/src/generated/body-schemas.ts
+++ b/src/generated/body-schemas.ts
@@ -3805,11 +3805,7 @@ export const BODY_SCHEMAS: Record<string, unknown> = {
        },
        "purchaseRequirement": {
         "type": "string",
-        "nullable": true,
-        "enum": [
-         "NO_COST_ASSOCIATED",
-         "IN_APP_PURCHASE"
-        ]
+        "nullable": true
        },
        "primaryLocale": {
         "type": "string",
@@ -3960,11 +3956,7 @@ export const BODY_SCHEMAS: Record<string, unknown> = {
        },
        "purchaseRequirement": {
         "type": "string",
-        "nullable": true,
-        "enum": [
-         "NO_COST_ASSOCIATED",
-         "IN_APP_PURCHASE"
-        ]
+        "nullable": true
        },
        "primaryLocale": {
         "type": "string",
@@ -9205,8 +9197,7 @@ export const BODY_SCHEMAS: Record<string, unknown> = {
         "enum": [
          "IOS",
          "MAC_OS",
-         "UNIVERSAL",
-         "SERVICES"
+         "UNIVERSAL"
         ]
        },
        "identifier": {
@@ -10968,8 +10959,7 @@ export const BODY_SCHEMAS: Record<string, unknown> = {
         "enum": [
          "IOS",
          "MAC_OS",
-         "UNIVERSAL",
-         "SERVICES"
+         "UNIVERSAL"
         ]
        },
        "udid": {
@@ -26073,71 +26063,6 @@ export const BODY_SCHEMAS: Record<string, unknown> = {
       },
       "id": {
        "type": "string"
-      },
-      "relationships": {
-       "type": "object",
-       "required": [
-        "territory"
-       ],
-       "properties": {
-        "territory": {
-         "type": "object",
-         "required": [
-          "data"
-         ],
-         "properties": {
-          "data": {
-           "type": "object",
-           "required": [
-            "type",
-            "id"
-           ],
-           "properties": {
-            "type": {
-             "type": "string",
-             "enum": [
-              "territories"
-             ]
-            },
-            "id": {
-             "type": "string"
-            }
-           },
-           "additionalProperties": false
-          }
-         },
-         "additionalProperties": false
-        },
-        "subscriptionPricePoint": {
-         "type": "object",
-         "required": [
-          "data"
-         ],
-         "properties": {
-          "data": {
-           "type": "object",
-           "required": [
-            "type",
-            "id"
-           ],
-           "properties": {
-            "type": {
-             "type": "string",
-             "enum": [
-              "subscriptionPricePoints"
-             ]
-            },
-            "id": {
-             "type": "string"
-            }
-           },
-           "additionalProperties": false
-          }
-         },
-         "additionalProperties": false
-        }
-       },
-       "additionalProperties": false
       }
      },
      "required": [


### PR DESCRIPTION
Apple's OpenAPI specification is still v4.4.1 and its content is not the content it was. `npm run spec:update` reports "unchanged" because it compares the version string; the file underneath carries sixteen differences.

**Six narrow what the API accepts** — the ones worth reading:

| Schema | Change |
|---|---|
| `BundleIdPlatform` | `SERVICES` dropped from the enum |
| `WinBackOfferPriceInlineCreate` | `relationships` removed |
| `appStoreVersionLocalizations`, `searchKeywords` (×3), `appCustomProductPageLocalizations` | list parameters gained an `items` enum |

**Three loosen instead.** `purchaseRequirement` lost its enum in `AppEvent` and in both of its request bodies, so the field is now an unconstrained string. `ResponseError` was deleted as a named schema and inlined into `ErrorResponse.errors.items` — the same shape by another route. `AppEvent.deepLink` gained a format.

No operation was added, removed or renamed: **still 982 tools**, every profile count unchanged. The generated diff is 83 lines of body schemas, and `REPORT.txt` moves by one kilobyte.

**About the 247,000 lines.** The stored spec was minified onto one line; Apple's download is pretty-printed. The weekly watch already expects this — its own comment says the first run normalises the file and the diffs after that are the changes. This is that run.

**Supersedes `spec/apple-update`**, which was cut before the spec-watch workflow was finished and carried seven bisect commits with it. That branch is deleted with this merge.

`npm run typecheck` clean, 521 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)