### PR TITLE
feat: say which app a write is about to change, and take its name

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project are documented here. The format is based on 
 ## English
 ### [Unreleased]
 
+#### A write says which app it is about to change
+`Target:     id = 6636549188` was the one line in the confirmation prompt that says *which* thing is being written to, and it was the one line nobody could read. The references inside a request body were resolved to names; the id in the path — the target itself — never was. A destructive write with no body at all named nothing.
+
+It now reads `id = 6636549188 (Ask Quran)`. The type comes from the path segment before the placeholder rather than a table, so a nested path is covered too: `/v1/apps/{id}/relationships/betaTesters` is still an app. Path targets and body references share one lookup budget and one deadline, so this costs no extra wait on a write that already had a body.
+
+
+#### The 46 app-rooted tools take an app name or bundle ID, like the macros always did
+`pricing__get_subscription_price` has always accepted `Ask Quran`, `com.example.app` or `6636549188`. `apps__update` accepted only the number, said `id`, and answered a bundle ID with a 404 — so the same request worked or failed depending on which tool the model reached for, and nothing in the schema said which was which.
+
+The generated tools rooted at `/v1/apps/{id}` now resolve a name or bundle ID the same way, and their `id` says so. Deliberately narrow: only a path segment that literally reads `apps`, and only a value that is not already numeric — which is a value Apple was going to reject anyway. A call that would have worked cannot change meaning, and an ambiguous name is an error rather than a guess, since picking the first of two apps is the exact accident this is meant to prevent.
+
+`TOKENS_PER_TOOL` moves 264 → 268 with it. Two earlier changes had already landed without the constant following them, so the figure `asc__status` reports was 4 low per tool across the whole catalogue.
+
+
 #### `preflight__check_version` — the rejection you can find before you submit
 Every gap this catches is one field on one resource, and every one of them comes back days later: a build still processing, an export-compliance answer nobody gave, a demo account marked required and left blank, a locale with no description. The version sits in `WAITING_FOR_EXPORT_COMPLIANCE` with nothing attached explaining why, or comes back rejected for something that took ten seconds to fix.
 
@@ -337,6 +351,20 @@ Safety and usability release: every write is now schema-checked locally, preview
 
 ## Türkçe
 ### [Unreleased]
+
+#### Bir yazma, hangi uygulamayı değiştireceğini söylüyor
+`Target:     id = 6636549188` — onay isteminde *neye* yazıldığını söyleyen tek satırdı ve okunamayan tek satır oydu. İstek gövdesinin içindeki referanslar adlara çevriliyordu; yoldaki kimlik, yani hedefin kendisi, hiç çevrilmiyordu. Gövdesi olmayan yıkıcı bir yazma hiçbir şeyi adlandırmıyordu.
+
+Artık `id = 6636549188 (Ask Quran)` yazıyor. Tip, bir tablodan değil yoldaki yer tutucudan önceki parçadan geliyor; iç içe yollar da kapsanıyor: `/v1/apps/{id}/relationships/betaTesters` hâlâ bir uygulama. Yol hedefleri ve gövde referansları tek arama bütçesini ve tek süreyi paylaşıyor, yani gövdesi zaten olan bir yazmaya ek bekleme getirmiyor.
+
+
+#### Uygulama köklü 46 araç, makroların hep aldığı gibi ad veya bundle ID alıyor
+`pricing__get_subscription_price` baştan beri `Ask Quran`, `com.example.app` ya da `6636549188` kabul ediyordu. `apps__update` yalnızca sayıyı kabul ediyor, `id` diyor ve bundle ID'ye 404 cevap veriyordu — yani aynı istek, modelin hangi araca uzandığına göre çalışıyor ya da düşüyordu, ve şemada hangisinin hangisi olduğunu söyleyen hiçbir şey yoktu.
+
+`/v1/apps/{id}` köklü üretilmiş araçlar artık adı veya bundle ID'yi aynı şekilde çözüyor ve `id` bunu söylüyor. Bilerek dar tutuldu: yalnızca düz `apps` yazan bir yol parçası ve yalnızca zaten sayısal olmayan bir değer — ki bu değeri Apple zaten reddedecekti. Çalışacak bir çağrının anlamı değişemez; belirsiz bir ad da tahmin değil hata, çünkü iki uygulamadan ilkini seçmek tam da önlenmek istenen kaza.
+
+`TOKENS_PER_TOOL` da 264 → 268 oluyor. Daha önceki iki değişiklik sabit güncellenmeden inmişti; `asc__status`'un bildirdiği rakam tüm katalog boyunca araç başına 4 eksikti.
+
 
 #### `preflight__check_version` — göndermeden önce bulunabilen ret
 Bunun yakaladığı her eksik, tek bir kaynaktaki tek bir alan; ve her biri günler sonra geri dönüyor: hâlâ işlenen bir build, kimsenin vermediği bir ihracat uyumluluğu cevabı, zorunlu işaretlenip boş bırakılmış bir demo hesabı, açıklaması olmayan bir dil. Sürüm `WAITING_FOR_EXPORT_COMPLIANCE`'ta nedenini açıklayan hiçbir şey olmadan bekliyor, ya da on saniyede düzeltilecek bir şey yüzünden reddedilmiş dönüyor.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -292,6 +292,8 @@ A handful of hand-written tools collapse a multi-step flow into one call. The ra
 | request → report → instance → segment → a signed URL | `analytics__get_report` — returns rows, not a link | `analytics` |
 | fetching reviews and grouping them by hand | `reviews_ai__triage`, `reviews_ai__daily_briefing`, `reviews_ai__draft_response` | `marketing:customer-review` |
 
+Naming an app works everywhere it is the target, not only in the macros: the 46 tools rooted at `/v1/apps/{id}` take a name, a bundle ID or the numeric Apple ID, and resolve it before the call. Only there, and only when the value is not already numeric — anywhere else an id is an id.
+
 Two of them do something the raw tools cannot do at all rather than merely faster: `listing__upload_screenshot` performs Apple's reserve → upload → commit sequence (the raw tool only reserves a slot and moves no bytes), and `analytics__get_report` downloads the report, where the raw chain ends holding a link.
 
 `pricing__equalize_price` is a REVENUE-level write covering about 175 countries. Run it under `--dry-run` first: it returns the full derived table before anything is sent.
@@ -631,6 +633,8 @@ Elle yazılmış birkaç araç, çok adımlı bir akışı tek çağrıya indiri
 | ekran görüntüsü için yer ayırıp baytları kendiniz taşımak | `listing__upload_screenshot` | `distribution:version` |
 | istek → rapor → örnek → segment → imzalı URL | `analytics__get_report` — bağlantı değil, satır döndürür | `analytics` |
 | yorumları çekip elle gruplamak | `reviews_ai__triage`, `reviews_ai__daily_briefing`, `reviews_ai__draft_response` | `marketing:customer-review` |
+
+Bir uygulamayı adıyla vermek yalnızca makrolarda değil, hedef olduğu her yerde çalışır: `/v1/apps/{id}` köklü 46 araç ad, bundle ID ya da sayısal Apple ID alır ve çağrıdan önce çözer. Yalnızca orada ve yalnızca değer zaten sayısal değilse — başka her yerde kimlik kimliktir.
 
 Bunlardan ikisi ham araçların daha hızlı yaptığı bir şeyi değil, hiç yapamadığı bir şeyi yapıyor: `listing__upload_screenshot` Apple'ın rezerve et → yükle → onayla dizisini yürütüyor (ham araç yalnızca yer ayırıyor, tek bayt taşımıyor) ve `analytics__get_report` raporu indiriyor — ham zincir elinde bir bağlantıyla bitiyor.
 

--- a/src/core/confirm.ts
+++ b/src/core/confirm.ts
@@ -225,7 +225,40 @@ export async function resolveBodyRefs(
 ): Promise<Map<string, string>> {
   const refs: Array<{ type: string; id: string }> = [];
   collectRefs(body, refs);
+  return resolveRefs(http, refs);
+}
 
+/**
+ * The `{id}` in the path, as a reference the resolver understands.
+ *
+ * `PATCH /v1/apps/{id}` names the app it is about to change and the preview
+ * printed the raw id — the one line in the prompt that says *which* thing is
+ * being written to was the one line nobody could read. The segment before the
+ * placeholder is the JSON:API type in Apple's spec, including on a nested path
+ * (`/v1/apps/{id}/relationships/betaTesters` is still an app), so the type
+ * comes from the path rather than from a table that would need maintaining.
+ */
+export function pathTargets(
+  path: string,
+  args: Record<string, unknown>
+): Array<{ type: string; id: string; param: string }> {
+  const targets: Array<{ type: string; id: string; param: string }> = [];
+  const segments = path.split('/');
+  segments.forEach((segment, i) => {
+    const param = /^\{(.+)\}$/.exec(segment)?.[1];
+    const type = segments[i - 1];
+    const value = param ? args[param] : undefined;
+    if (param && type && typeof value === 'string' && resolvable(type)) {
+      targets.push({ type, id: value, param });
+    }
+  });
+  return targets;
+}
+
+async function resolveRefs(
+  http: RefReader,
+  refs: Array<{ type: string; id: string }>
+): Promise<Map<string, string>> {
   const seen = new Set<string>();
   const unique = refs.filter((r) => {
     const key = `${r.type}/${r.id}`;
@@ -344,16 +377,25 @@ export async function buildWritePreview(
     `Operation:  ${op.method} ${op.path}`,
   ];
 
+  // Path targets and body references share one lookup budget and one deadline,
+  // so naming the target costs no extra wait on a write that also carries a
+  // body — and a write with no body finally names its target at all.
+  const body = (args.body as any)?.data;
+  const targets = pathTargets(op.path, args);
+  const bodyRefs: Array<{ type: string; id: string }> = [];
+  if (body) collectRefs(body, bodyRefs);
+  const labels = http ? await resolveRefs(http, [...targets, ...bodyRefs]) : new Map<string, string>();
+
   const ids = Object.entries(args)
     .filter(([k, v]) => k !== 'body' && typeof v === 'string' && op.path.includes(`{${k}}`))
-    .map(([k, v]) => `${k} = ${v}`);
+    .map(([k, v]) => {
+      const label = labels.get(`${targets.find((t) => t.param === k)?.type}/${v}`);
+      return label ? `${k} = ${v} (${label})` : `${k} = ${v}`;
+    });
   if (ids.length) lines.push(`Target:     ${ids.join(', ')}`);
   if (account) lines.push(`Account:    ${account}`);
 
-  const body = (args.body as any)?.data;
   if (body) {
-    const labels = http ? await resolveBodyRefs(http, body) : new Map<string, string>();
-
     // The two labels that answer "what am I approving?" get their own lines.
     for (const [key, label] of labels) {
       if (key.startsWith('subscriptions/')) lines.push(`Product:    ${label}`);

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -6,6 +6,7 @@ import type { AscHttpClient, Query } from './http.js';
 import { OPERATIONS } from '../generated/operations.js';
 import { BODY_SCHEMAS } from '../generated/body-schemas.js';
 import { AscApiError } from './errors.js';
+import { resolveApp } from './resolve-app.js';
 import { validateBody } from './validate.js';
 import type { RiskLevel } from './risk.js';
 import {
@@ -173,6 +174,14 @@ const ANNOUNCED_RISKS: ReadonlySet<RiskLevel> = new Set<RiskLevel>([
   'access',
 ]);
 
+/**
+ * Whether this operation's `{id}` is an app's — the one path parameter the
+ * server will resolve from a name or bundle ID.
+ */
+function appRootedId(op: { path: string }): boolean {
+  return /^\/v\d+\/apps\/\{id\}/.test(op.path);
+}
+
 function describeOperation(op: Operation): string {
   // The endpoint is appended so the model can reason about REST semantics
   // (and so a human reading the tool list can cross-reference Apple's docs).
@@ -209,7 +218,18 @@ export function toMcpTool(
           // name does not. See task-7-report.md and AI-217.
           // Every word here is paid 678 times, so it says the one thing the
           // parameter name cannot: where the value comes from.
-          { type: 'string', description: 'ID from the matching list call.' }
+          //
+          // The 46 app-rooted operations say more, because they accept more:
+          // the server resolves a name or bundle ID here (see resolvePathValue),
+          // and a tool that takes one without saying so is a tool nobody hands
+          // one to.
+          appRootedId(op)
+          ? {
+              type: 'string',
+              description:
+                'App name, bundle ID (com.example.app) or numeric Apple ID.',
+            }
+          : { type: 'string', description: 'ID from the matching list call.' }
         : { type: 'string', description: `Path parameter "${param}".` };
     required.push(param);
   }
@@ -381,6 +401,35 @@ export class ToolRegistry {
     return ALL_DOMAINS.filter((d) => !loaded.has(d));
   }
 
+  /**
+   * An app named where an Apple ID belongs.
+   *
+   * The macros have always taken an app the way a person says one — a name, a
+   * bundle ID, the numeric id — and the generated tools took only the number.
+   * So the same request either worked or 404'd depending on which tool the
+   * model reached for, and the model had no way to know: `apps__update` says
+   * "id", and `com.example.app` is a perfectly reasonable thing to put there.
+   *
+   * Narrow on purpose. Only a path segment that literally reads `apps` and only
+   * a value that is not already numeric, which is a value Apple was going to
+   * reject anyway — so this converts a certain failure into a lookup, and never
+   * changes the meaning of a call that would have worked. An ambiguous name is
+   * an error rather than a guess, because picking the first of two apps is the
+   * exact accident this is meant to prevent.
+   */
+  private async resolvePathValue(
+    http: AscHttpClient,
+    path: string,
+    param: string,
+    value: string
+  ): Promise<string> {
+    if (/^\d+$/.test(value)) return value;
+    const segments = path.split('/');
+    const owner = segments[segments.indexOf(`{${param}}`) - 1];
+    if (owner !== 'apps') return value;
+    return (await resolveApp(http, value)).id;
+  }
+
   async execute(
     name: string,
     args: Record<string, unknown>,
@@ -438,7 +487,10 @@ export class ToolRegistry {
       if (value === undefined || value === null || value === '') {
         throw new AscApiError(`Missing required parameter "${param}" for ${name}.`, 0);
       }
-      path = path.replace(`{${param}}`, encodeURIComponent(String(value)));
+      path = path.replace(
+        `{${param}}`,
+        encodeURIComponent(await this.resolvePathValue(http, op.path, param, String(value)))
+      );
     }
 
     // An argument nobody recognises used to be dropped without a word, and the

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -242,16 +242,19 @@ export function manualToolsFor(selection: ProfileSelection): string[] {
 /**
  * Rough tokens a tool definition costs in context — for size hints only.
  * Measured by `npm run generate`'s token report over the full generated
- * corpus: 258,877 definition tokens / 982 tools = 264 avg. Re-measure and
+ * corpus: 263,040 definition tokens / 982 tools = 268 avg. Re-measure and
  * update this after any change to `toMcpTool` or the generator. It has moved
- * four times and every move was paid for: shortening the repeated `next_url`
+ * five times and every move was paid for: shortening the repeated `next_url`
  * and `id` descriptions took it 225 to 213, the sparse-fieldset params
- * (fields[...]) took it back to 254, and giving `id` a description again
- * (AI-217) to 264 — because on a delete or a relationship read `id` is the
- * only parameter, and an undescribed one is a tool that documents nothing
- * about its input.
+ * (fields[...]) took it back to 254, giving `id` a description again (AI-217)
+ * to 264 — because on a delete or a relationship read `id` is the only
+ * parameter, and an undescribed one is a tool that documents nothing about its
+ * input — and telling the 46 app-rooted tools that their `id` also takes a name
+ * or bundle ID to 268. Two of those moves had already landed without the
+ * constant following them; it is 4 too low across the whole catalogue, which is
+ * most of what `asc__status` reports.
  */
-export const TOKENS_PER_TOOL = 264;
+export const TOKENS_PER_TOOL = 268;
 
 /** How many tools a selection serves, meta tools included. */
 export function toolCountFor(selection: ProfileSelection): number {

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -331,6 +331,60 @@ describe('ToolRegistry', () => {
     expect(registry.unloadedDomains()).not.toContain('apps');
   });
 
+  // The macros have always taken an app the way a person says one; the
+  // generated tools took only the number, so the same request worked or 404'd
+  // depending on which tool the model reached for.
+  describe('an app named where an Apple ID belongs', () => {
+    // Both entry points, because resolveApp calls `get` and the execute path
+    // itself goes through `request`.
+    const spy = (data: unknown) => {
+      const paths: string[] = [];
+      const record = async (path: string) => {
+        paths.push(path);
+        return data;
+      };
+      return {
+        paths,
+        http: {
+          get: record,
+          request: (_method: string, path: string) => record(path),
+        } as never,
+      };
+    };
+
+    it('resolves a bundle ID on an app-rooted path', async () => {
+      const registry = new ToolRegistry({ domains: ['all'], readOnly: false, includeDeprecated: false });
+      const { paths, http } = spy({ data: [{ id: '6636549188', attributes: { name: 'Ask Quran' } }] });
+      await registry.execute('apps__get', { id: 'com.milowda.askquranai' }, http);
+      expect(paths[0]).toBe('/v1/apps');
+      expect(paths[1]).toBe('/v1/apps/6636549188');
+    });
+
+    it('spends no lookup on a value Apple would have accepted', async () => {
+      const registry = new ToolRegistry({ domains: ['all'], readOnly: false, includeDeprecated: false });
+      const { paths, http } = spy({ data: { id: '6636549188' } });
+      await registry.execute('apps__get', { id: '6636549188' }, http);
+      expect(paths).toEqual(['/v1/apps/6636549188']);
+    });
+
+    it('leaves a non-app id alone, however unlike a number it looks', async () => {
+      // Most Apple ids are UUIDs. Resolving those as app names would turn a
+      // working call into a search that finds nothing.
+      const registry = new ToolRegistry({ domains: ['all'], readOnly: false, includeDeprecated: false });
+      const { paths, http } = spy({ data: { id: 'x' } });
+      await registry.execute('builds__get', { id: '8f0c-not-a-number' }, http);
+      expect(paths).toEqual(['/v1/builds/8f0c-not-a-number']);
+    });
+
+    it('says so in the schema, since a tool nobody knows takes a name gets none', () => {
+      const registry = new ToolRegistry({ domains: ['all'], readOnly: false, includeDeprecated: false });
+      const appsGet = registry.listTools().find((t) => t.name === 'apps__get')!;
+      const buildsGet = registry.listTools().find((t) => t.name === 'builds__get')!;
+      expect((appsGet.inputSchema.properties as any).id.description).toContain('bundle ID');
+      expect((buildsGet.inputSchema.properties as any).id.description).toBe('ID from the matching list call.');
+    });
+  });
+
   it('refuses to execute a mutating tool in read-only mode', async () => {
     const registry = new ToolRegistry({ domains: ['all'], readOnly: false, includeDeprecated: false });
     const readOnly = new ToolRegistry({ domains: ['all'], readOnly: true, includeDeprecated: false });

--- a/tests/risk.test.ts
+++ b/tests/risk.test.ts
@@ -139,6 +139,48 @@ describe('reference resolution in a preview', () => {
   });
 });
 
+describe('the preview names the thing it is about to write to', () => {
+  const named = (attributes: Record<string, unknown>) => ({
+    get: async () => ({ data: { attributes } }),
+  });
+
+  // The one line that says *which* app is being changed was the one line
+  // nobody could read: "Target: id = 6636549188".
+  it('resolves the path id, not only the references in the body', async () => {
+    const preview = await buildWritePreview(
+      'apps__update',
+      { method: 'PATCH', path: '/v1/apps/{id}', risk: 'public' },
+      { id: '6636549188', body: { data: { type: 'apps', id: '6636549188', attributes: {} } } },
+      undefined,
+      named({ name: 'Ask Quran' })
+    );
+    expect(preview.message).toContain('Target:     id = 6636549188 (Ask Quran)');
+  });
+
+  it('names it on a write that carries no body at all', async () => {
+    const preview = await buildWritePreview(
+      'apps__beta_testers__remove',
+      { method: 'DELETE', path: '/v1/apps/{id}/relationships/betaTesters', risk: 'destructive' },
+      { id: '6636549188' },
+      undefined,
+      named({ name: 'Ask Quran' })
+    );
+    expect(preview.message).toContain('(Ask Quran)');
+  });
+
+  it('falls back to the bare id when the lookup says nothing', async () => {
+    const preview = await buildWritePreview(
+      'apps__update',
+      { method: 'PATCH', path: '/v1/apps/{id}', risk: 'public' },
+      { id: '6636549188' },
+      undefined,
+      { get: async () => ({ data: {} }) }
+    );
+    expect(preview.message).toContain('Target:     id = 6636549188');
+    expect(preview.message).not.toContain('(');
+  });
+});
+
 describe('buildWritePreview', () => {
   const op = {
     method: 'POST',


### PR DESCRIPTION
Closes MIL-194.

Two halves of the same problem the ticket opens with — an agent carrying an opaque Apple ID through every call, with nothing on either end that reads as an app.

**The output.** The confirmation prompt resolved the references *inside* a request body to names and left the id in the path — the target itself — as a number. A destructive write with no body named nothing at all.

```
Target:     id = 6636549188            → id = 6636549188 (Ask Quran)
```

The type comes from the path segment before the placeholder rather than a table, so nested paths are covered: `/v1/apps/{id}/relationships/betaTesters` is still an app. Path targets and body references share one lookup budget and one deadline, so a write that already had a body waits no longer than before.

**The input.** `pricing__get_subscription_price` has always taken `Ask Quran`, `com.example.app` or `6636549188`. `apps__update` took only the number, said `id`, and answered a bundle ID with a 404 — so the same request worked or failed depending on which tool the model reached for, and nothing in the schema said which was which. The 46 tools rooted at `/v1/apps/{id}` now resolve a name or bundle ID, and their `id` description says so.

Narrow on purpose: only a path segment that literally reads `apps`, and only a value that is not already numeric — a value Apple was going to reject anyway. A call that would have worked cannot change meaning. An ambiguous name is an error rather than a guess, since picking the first of two apps is the accident this exists to prevent. Most Apple ids are UUIDs, and resolving those as app names would turn a working call into a search that finds nothing.

---

**Not built: the alias file and `asc__set_current_app`.**

A local alias→id mapping is a second source of truth for something Apple already answers, and it is the kind that goes stale silently — an app renamed in App Store Connect leaves the file pointing at a name that no longer exists, and nothing notices. `resolveApp` asks Apple, which is right by construction.

`set_current_app` is worse for the ticket's own stated goal. Hidden session state that changes what a subsequent call means is precisely how a write lands on the wrong app: the model believes the context is one thing, the server holds another, and neither the tool call nor the confirmation prompt shows the disagreement. Naming the target in the prompt closes that gap instead of adding a place for it to open.

---

`TOKENS_PER_TOOL` moves 264 → 268. Two earlier changes had already landed without the constant following them, so what `asc__status` reports was 4 low per tool across the whole catalogue, not only for these 46.

Seven new tests. 538 passing, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)