### PR TITLE
docs: answer "which profile do I install" by role, and work seven scenarios through

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Most App Store Connect MCP servers offer a hand-picked slice of the API. That wo
 
 Register only the profiles your project uses. What each one covers is in the [profile table](docs/GUIDE.md#register-profiles); adding and removing them later is [here](docs/GUIDE.md#adding-and-removing-later).
 
+Not sure which? [Starter packs](docs/GUIDE.md#starter-packs) answers it by role — a release manager installs `distribution` + `app-info`, an ASO team `marketing` + `analytics` — and [examples/](examples/README.md) works each one through, including the part that usually goes wrong.
+
 There is nothing to memorise — ask *"is there a tool for in-app events?"* and `asc__search_tools` searches everything, including what isn't loaded, and tells you which profile it lives in.
 
 #### Risky writes ask first
@@ -93,6 +95,7 @@ Heimdall is not a Fastlane alternative — it is the interactive half. Keep [Fas
 ### Documentation
 
 - [Guide](docs/GUIDE.md) — API key, install, setup wizard, profiles, configuration, examples
+- [Examples](examples/README.md) — starter packs by role, seven worked scenarios, and a GitHub Actions workflow
 - [Security](.github/SECURITY.md) — credential handling, safety modes, pre-install audit, vulnerability reporting
 - [Support](.github/SUPPORT.md) — getting help, troubleshooting
 - [Changelog](docs/CHANGELOG.md) — release history
@@ -176,6 +179,8 @@ Adım adım anlatım [Rehber](docs/GUIDE.md)’de.
 
 Sadece projenizin kullandığı profilleri kaydedin. Hangisinin neyi kapsadığı [profil tablosunda](docs/GUIDE.md#profilleri-kaydedin), sonradan ekleme ve çıkarma [burada](docs/GUIDE.md#sonradan-ekleme-ve-çıkarma).
 
+Hangisi olduğundan emin değil misiniz? [Başlangıç paketleri](docs/GUIDE.md#başlangıç-paketleri) bunu role göre cevaplıyor — yayın yöneticisi `distribution` + `app-info` kurar, ASO ekibi `marketing` + `analytics` — ve [examples/](examples/README.md) her birini, genelde nerede ters gittiğiyle birlikte, baştan sona işliyor.
+
 Hiçbir şeyi ezberlemeniz gerekmez — *"uygulama içi etkinlikler için bir araç var mı?"* diye sorun; `asc__search_tools` o an yüklü olmayanlar dahil hepsini arar ve hangi profilde olduğunu söyler.
 
 #### Riskli yazmalar önce sorar
@@ -195,6 +200,7 @@ Heimdall bir Fastlane alternatifi değil, interaktif yarısıdır. Tekrarlanabil
 ### Dokümantasyon
 
 - [Rehber](docs/GUIDE.md) — API anahtarı, kurulum, setup sihirbazı, profiller, yapılandırma, örnekler
+- [Örnekler](examples/README.md) — role göre başlangıç paketleri, yedi işlenmiş senaryo ve bir GitHub Actions workflow'u
 - [Güvenlik](.github/SECURITY.md) — kimlik bilgisi yönetimi, güvenlik modları, kurulum öncesi denetim, açık bildirimi
 - [Destek](.github/SUPPORT.md) — yardım alma, sorun giderme
 - [Değişiklik günlüğü](docs/CHANGELOG.md) — sürüm geçmişi

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project are documented here. The format is based on 
 ## English
 ### [Unreleased]
 
+#### Starter packs, and seven scenarios worked through
+"Which profile do I install?" had one answer and it was a table of thirteen rows sorted by nothing in particular. There is a second answer now, by role: a release manager installs `distribution` + `app-info`, an ASO team `marketing` + `analytics`, customer support `monetization:storekit` and eighteen tools. Seven packs, in the guide and in the README, with tool counts a test keeps honest — `docs/GUIDE.md` carried "distribution … 129" through two releases where the number was 130, because prose has no tests.
+
+`examples/` is new and is the other half. Seven scenarios — sales and finance reports, TestFlight invitations, creating a version and attaching a build, review triage, keywords for one language, sandbox testers, CI — each saying which profile it needs and, more usefully, the part that usually goes wrong. Finance and sales are different reports and "revenue" almost always means the first. A tester belongs to the account before they belong to a group. Keywords live on the version localization and the name lives somewhere else entirely, because one belongs to the release and the other to the app.
+
+`examples/ci/release-notes.yml` is a working GitHub Actions workflow: an agent reads the commits since the last tag, writes the "What's New" text, and puts it on the version. It rehearses by default — `dry_run: true` — so a first run cannot reach Apple, and it sets `ASC_CONFIRM_WRITES=0` explicitly rather than letting the write fail closed. No user is present on a runner to answer a confirmation prompt, and a gate refusing a write it was never going to get an answer for reads, in a log, exactly like a bug.
+
+
 #### 143 of 265 real phrasings now find their tool in the top three, up from 83
 `asc__search_tools` is how a model gets from "make the subscription available in Germany" to the one call that does it, and on a measured corpus of 265 phrasings it was landing the right tool in the top three 83 times. It is 143 now, with no phrasing losing a place it had.
 
@@ -363,6 +371,14 @@ Safety and usability release: every write is now schema-checked locally, preview
 
 ## Türkçe
 ### [Unreleased]
+
+#### Başlangıç paketleri ve baştan sona işlenmiş yedi senaryo
+"Hangi profili kurayım?" sorusunun tek cevabı vardı ve o da özel bir sıraya göre dizilmemiş on üç satırlık bir tabloydu. Artık ikinci bir cevap var, role göre: yayın yöneticisi `distribution` + `app-info` kurar, ASO ekibi `marketing` + `analytics`, müşteri desteği `monetization:storekit` ve on sekiz araç. Yedi paket; rehberde ve README'de, araç sayılarını dürüst tutan bir testle birlikte — `docs/GUIDE.md` iki sürüm boyunca "distribution … 129" yazdı, doğrusu 130'du, çünkü düzyazının testi yok.
+
+`examples/` yeni ve işin diğer yarısı. Yedi senaryo — satış ve finans raporları, TestFlight daveti, sürüm oluşturup build bağlama, yorum triyajı, tek dilin anahtar kelimeleri, sandbox testçileri, CI — her biri hangi profili gerektirdiğini ve daha da işe yararı, genelde nerede ters gittiğini söylüyor. Finans ve satış farklı raporlar ve "gelir" neredeyse her zaman birincisi demek. Testçi, gruba ait olmadan önce hesaba ait olur. Anahtar kelimeler sürüm yerelleştirmesinde, ad ise bambaşka bir yerde yaşar; çünkü biri yayına, diğeri uygulamaya ait.
+
+`examples/ci/release-notes.yml` çalışan bir GitHub Actions workflow'u: bir ajan son tag'den beri gelen commit'leri okuyor, "Yenilikler" metnini yazıyor ve sürüme koyuyor. Varsayılan olarak prova yapıyor — `dry_run: true` — yani ilk koşu Apple'a ulaşamaz; ve `ASC_CONFIRM_WRITES=0`'ı yazmanın kapıda kapanmasına bırakmak yerine açıkça ayarlıyor. Runner'da onay istemini cevaplayacak kullanıcı yok ve zaten cevap alamayacağı bir yazmayı reddeden bir kapı, logda tam olarak bir hata gibi okunur.
+
 
 #### 265 gerçek ifadeden 143'ü aracını ilk üçte buluyor, önce 83'tü
 `asc__search_tools`, modelin "aboneliği Almanya'da satışa aç"tan bunu yapan tek çağrıya ulaşma yolu; ölçülmüş 265 ifadelik havuzda doğru aracı ilk üçe 83 kez getiriyordu. Artık 143, ve hiçbir ifade elindeki yeri kaybetmedi.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -93,6 +93,28 @@ One install backs thirteen small, purpose-built MCP servers. Pass a profile name
 
 Every profile also carries the **core set** — `apps__list`, `apps__get`, the four shared relationship listings, and `asc__status` / `asc__search_tools` / `asc__discover_domains`. So whichever profile you install can look up an app ID and point you to a tool it doesn't have.
 
+#### Starter packs
+
+"Which profile do I install?" answered by role rather than by browsing the table above. Every one of these also carries the core set, so it can find an app ID and point you at a tool it does not have.
+
+| You are | Install | Tools |
+|:--|:--|--:|
+| Release manager | `distribution` + `app-info` | 187 |
+| ASO / marketing | `marketing` + `analytics` | 123 |
+| QA / TestFlight | `testflight` + `access` | 118 |
+| Monetization | `monetization` | 206 |
+| Game developer | `game-center` + `distribution` | 312 |
+| Customer support | `monetization:storekit` | 18 |
+| Build & signing | `provisioning` + `xcode-cloud` | 100 |
+
+```bash
+npx -y @erayendes/asc-mcp register distribution app-info
+```
+
+Start narrower than feels safe. Nothing is lost by skipping a profile: `asc__call` reaches any operation in the catalogue whether it is loaded or not, and `asc__search_tools` names the profile that carries it. Adding one later is a line of config, while every tool you loaded and never called is paid for in every session.
+
+Worked examples for each of these — with the part that usually goes wrong — are in [examples/](../examples/README.md).
+
 #### Pick per project
 
 MCP connects every configured server at session start — there's no "load the right server for the topic" mechanism. So the practical form of on-demand loading is to register only the profiles a project uses. A revenue project gets `asc-analytics` + `asc-marketing` (122 tools); a game adds `asc-game-center`. Agents defer tool schemas until first use, keeping even several connected profiles cheap.
@@ -441,6 +463,28 @@ Tek kurulum, on üç küçük, amaca özel MCP sunucusu sunar. Profil adını ve
 | `webhooks` | Webhook yapılandırma ve teşhis | 17 | — |
 
 Her profil ayrıca **çekirdek kümeyi** taşır — `apps__list`, `apps__get`, dört ortak ilişki listelemesi ve `asc__status` / `asc__search_tools` / `asc__discover_domains`. Yani hangi profili kurarsanız kurun, bir uygulama ID'si bulabilir ve sahip olmadığı bir aracın yerini size gösterebilir.
+
+#### Başlangıç paketleri
+
+"Hangi profili kurayım?" sorusunun, yukarıdaki tabloyu taramak yerine role göre cevabı. Bunların hepsi çekirdek seti de taşır; yani bir app ID bulabilir ve sahip olmadığı bir aracı size gösterebilir.
+
+| Siz | Kurun | Araç |
+|:--|:--|--:|
+| Yayın yöneticisi | `distribution` + `app-info` | 187 |
+| ASO / pazarlama | `marketing` + `analytics` | 123 |
+| QA / TestFlight | `testflight` + `access` | 118 |
+| Monetizasyon | `monetization` | 206 |
+| Oyun geliştirici | `game-center` + `distribution` | 312 |
+| Müşteri desteği | `monetization:storekit` | 18 |
+| Build ve imzalama | `provisioning` + `xcode-cloud` | 100 |
+
+```bash
+npx -y @erayendes/asc-mcp register distribution app-info
+```
+
+Güvenli hissettirenden dar başlayın. Bir profili atlamakla hiçbir şey kaybetmezsiniz: `asc__call` katalogdaki her işleme yüklü olsun olmasın ulaşır, `asc__search_tools` da onu taşıyan profili söyler. Sonradan eklemek bir satır yapılandırma; yükleyip hiç çağırmadığınız her aracın bedeli ise her oturumda ödenir.
+
+Her biri için — ve genelde nerede ters gittiğiyle birlikte — çalışılmış örnekler: [examples/](../examples/README.md).
 
 #### Projeye göre seçin
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,291 @@
+# Examples / Örnekler
+
+🇬🇧 [English](#english) · 🇹🇷 [Türkçe](#türkçe)
+
+Heimdall takes plain language. What follows is not a syntax to learn — it is the
+set of things people actually ask for, with the profile each one needs and the
+part that usually goes wrong.
+
+---
+
+## English
+
+### Starter packs
+
+Register only what the project uses. Every profile carries the core set
+(`apps__list`, `apps__get`, `asc__search_tools`, `asc__status`), so whichever
+one you install can find an app ID and point you at a tool it does not have.
+
+| You are | Install | Tools |
+|:--|:--|--:|
+| Release manager | `distribution` + `app-info` | 187 |
+| ASO / marketing | `marketing` + `analytics` | 123 |
+| QA / TestFlight | `testflight` + `access` | 118 |
+| Monetization | `monetization` | 206 |
+| Game developer | `game-center` + `distribution` | 312 |
+| Customer support | `monetization:storekit` | 18 |
+| Build & signing | `provisioning` + `xcode-cloud` | 100 |
+
+```bash
+npx -y @erayendes/asc-mcp register distribution app-info
+```
+
+Narrower is better than broader: `monetization:subscription-pricing` is 26
+tools where `monetization` is 206, and everything you skipped is one
+`asc__call` away — the proxy reaches any operation in the catalogue, loaded or
+not.
+
+---
+
+### Pull a sales or finance report
+
+> Download last month's sales report and tell me the top five countries by
+> units.
+
+Needs `analytics`, and `ASC_VENDOR_NUMBER` set. Two things trip this up:
+
+- **Finance and sales are different reports.** `finance_reports__list` is what
+  Apple paid you, by region and currency. `sales_reports__list` is units and
+  proceeds, by day or week. "Revenue" usually means the first one.
+- **They arrive as gzipped TSV**, not JSON. Ask for `parse=true` and you get
+  rows back; without it you get a base64 blob nobody can read. If the report is
+  large the full copy is kept as an MCP resource and the reply links to it.
+
+---
+
+### Invite a TestFlight tester
+
+> Add sara@example.com to the Insiders group and give her the latest build.
+
+Needs `access` (groups, testers) and `testflight` (build localizations, review
+details). Order matters and the API will not tell you: a tester belongs to the
+account first, then to a group, then a build is served to the group. Adding an
+email to a group creates the tester if they do not exist yet.
+
+An **external** group needs Apple to review the build before it reaches anyone.
+An internal group does not. If testers report seeing nothing, that is usually
+the reason.
+
+---
+
+### Create a version and attach a build
+
+> Start version 3.2, attach build 412, and tell me what is still missing before
+> I can submit.
+
+Needs `distribution`. The last clause is one call: `preflight__check_version`
+reads the version, its build, the review contact, every localization and the
+screenshots, and answers with what is missing and which tool fixes each gap.
+
+The two failures worth knowing about, because neither reports itself:
+
+- A build still **PROCESSING** cannot be attached, and Apple says nothing about
+  when it will finish.
+- `usesNonExemptEncryption` unanswered parks the version at
+  `WAITING_FOR_EXPORT_COMPLIANCE` after submission, with no explanation
+  attached to it.
+
+---
+
+### Triage reviews and draft replies
+
+> Show me this week's 1-star reviews with no response, and draft replies in the
+> reviewer's language.
+
+Needs `marketing`. `reviews_ai__triage` groups them and
+`reviews_ai__draft_response` writes a reply — **your** model writes it, using
+your client's sampling. There is no second API key and no text leaves for
+anyone else's model.
+
+Set `ASC_REVIEWS_BRAND_VOICE`, `ASC_REVIEWS_BANNED_PHRASES` and
+`ASC_REVIEWS_SUPPORT_URL` if replies should sound like your team rather than
+like a language model.
+
+---
+
+### Update keywords for one language
+
+> Replace the Turkish keywords with these, and leave every other language
+> alone.
+
+Needs `distribution`. Keywords live on the *version* localization, one row per
+language, capped at 100 characters — and the cap counts commas. Name and
+subtitle live somewhere else entirely (`app_info_localizations`), because they
+belong to the app rather than to a version.
+
+Ask for one locale by name. A listing with fifty languages is 264 KB fetched
+whole, and the useful answer is one row of it.
+
+---
+
+### Manage sandbox testers
+
+> Clear the purchase history for our sandbox account and set its territory to
+> Turkey.
+
+Needs `monetization`. Sandbox testers are accounts you create in App Store
+Connect, not real Apple IDs; clearing purchase history is what makes a
+subscription purchasable again in testing, and it is a separate call from
+editing the tester.
+
+---
+
+### Run it in CI
+
+[`ci/release-notes.yml`](ci/release-notes.yml) is a working GitHub Actions
+workflow: an agent reads the commits since the last tag, writes release notes,
+and puts them in the App Store version's "What's New" field.
+
+Three things about credentials and flags in CI:
+
+- **`ASC_PRIVATE_KEY` as an inline PEM** is the right form here. The Keychain
+  does not exist on a runner and a key file on disk is one more thing to clean
+  up.
+- **`--no-confirm`** is required for any write, and it is honest rather than
+  reckless: there is no user to answer a prompt, so the default `strong` gate
+  would refuse the write and report it as a refusal. Say so explicitly instead
+  of appearing to hang.
+- **`--read-only`** for anything that only reports. A job that cannot write
+  cannot write by accident, which is worth more than a careful prompt.
+
+Run the whole thing under **`--dry-run`** first. Every write comes back as what
+*would* have been sent — method, path, body, risk level — after validation, and
+nothing reaches Apple.
+
+---
+
+## Türkçe
+
+### Başlangıç paketleri
+
+Yalnızca projenin kullandığını kaydedin. Her profil çekirdek seti taşıyor
+(`apps__list`, `apps__get`, `asc__search_tools`, `asc__status`); yani hangisini
+kurarsanız kurun, bir app ID bulabilir ve sahip olmadığı bir aracı size
+gösterebilir.
+
+| Siz | Kurun | Araç |
+|:--|:--|--:|
+| Yayın yöneticisi | `distribution` + `app-info` | 187 |
+| ASO / pazarlama | `marketing` + `analytics` | 123 |
+| QA / TestFlight | `testflight` + `access` | 118 |
+| Monetizasyon | `monetization` | 206 |
+| Oyun geliştirici | `game-center` + `distribution` | 312 |
+| Müşteri desteği | `monetization:storekit` | 18 |
+| Build ve imzalama | `provisioning` + `xcode-cloud` | 100 |
+
+```bash
+npx -y @erayendes/asc-mcp register distribution app-info
+```
+
+Dar olan geniş olandan iyidir: `monetization:subscription-pricing` 26 araç,
+`monetization` 206. Atladığınız her şey bir `asc__call` uzaklıkta — proxy,
+yüklü olsun olmasın katalogdaki her işleme ulaşır.
+
+---
+
+### Satış veya finans raporu çek
+
+> Geçen ayın satış raporunu indir ve adet bazında ilk beş ülkeyi söyle.
+
+`analytics` ve `ASC_VENDOR_NUMBER` gerekir. İki nokta takılıyor:
+
+- **Finans ve satış farklı raporlar.** `finance_reports__list` Apple'ın size
+  ödediği; bölge ve para birimi bazında. `sales_reports__list` adet ve hasılat;
+  gün ya da hafta bazında. "Gelir" genelde birincisi demek.
+- **Gzip'li TSV olarak gelirler**, JSON değil. `parse=true` isterseniz satır
+  alırsınız; istemezseniz kimsenin okuyamayacağı bir base64 blob. Rapor büyükse
+  tam kopyası MCP kaynağı olarak saklanır ve cevap ona bağlanır.
+
+---
+
+### TestFlight testçisi davet et
+
+> sara@example.com'u Insiders grubuna ekle ve en son build'i ver.
+
+`access` (gruplar, testçiler) ve `testflight` (build yerelleştirmeleri,
+inceleme detayları) gerekir. Sıra önemli ve API bunu söylemiyor: testçi önce
+hesaba, sonra gruba ait olur, build ise gruba sunulur. Bir e-postayı gruba
+eklemek, testçi yoksa onu oluşturur.
+
+**Harici** bir grup için Apple'ın build'i incelemesi gerekir; dahili grup için
+gerekmez. Testçiler "hiçbir şey görünmüyor" diyorsa sebep genelde budur.
+
+---
+
+### Sürüm oluştur ve build bağla
+
+> 3.2 sürümünü başlat, 412 build'ini bağla ve göndermeden önce ne eksik söyle.
+
+`distribution` gerekir. Son cümle tek çağrı: `preflight__check_version` sürümü,
+build'ini, inceleme iletişimini, her yerelleştirmeyi ve ekran görüntülerini
+okuyup neyin eksik olduğunu ve her eksiği hangi aracın düzelteceğini söyler.
+
+Bilinmeye değer iki arıza, ikisi de kendini bildirmiyor:
+
+- Hâlâ **PROCESSING** olan bir build bağlanamaz ve Apple ne zaman biteceğini
+  söylemez.
+- `usesNonExemptEncryption` cevapsızsa sürüm gönderimden sonra
+  `WAITING_FOR_EXPORT_COMPLIANCE`'ta bekler; hiçbir açıklama iliştirilmez.
+
+---
+
+### Yorumları triyaj et ve cevap taslağı yaz
+
+> Bu haftanın cevapsız 1 yıldızlı yorumlarını göster ve yorumun dilinde cevap
+> taslağı yaz.
+
+`marketing` gerekir. `reviews_ai__triage` onları gruplar,
+`reviews_ai__draft_response` cevabı yazar — **sizin** modeliniz yazar,
+istemcinizin sampling'i üzerinden. İkinci bir API anahtarı yok ve hiçbir metin
+başkasının modeline gitmiyor.
+
+Cevaplar bir dil modeli gibi değil ekibiniz gibi konuşsun istiyorsanız
+`ASC_REVIEWS_BRAND_VOICE`, `ASC_REVIEWS_BANNED_PHRASES` ve
+`ASC_REVIEWS_SUPPORT_URL` ayarlayın.
+
+---
+
+### Tek dilin anahtar kelimelerini güncelle
+
+> Türkçe anahtar kelimeleri bunlarla değiştir, diğer dillere dokunma.
+
+`distribution` gerekir. Anahtar kelimeler *sürüm* yerelleştirmesinde yaşar, dil
+başına bir satır, 100 karakter sınırlı — ve sınır virgülleri de sayar. Ad ve
+alt başlık bambaşka bir yerde (`app_info_localizations`), çünkü sürüme değil
+uygulamaya aitler.
+
+Tek bir dili adıyla isteyin. Elli dilli bir liste bütün hâlde 264 KB ve işe
+yarayan cevap onun tek satırı.
+
+---
+
+### Sandbox test kullanıcılarını yönet
+
+> Sandbox hesabımızın satın alma geçmişini temizle ve ülkesini Türkiye yap.
+
+`monetization` gerekir. Sandbox testçileri App Store Connect'te oluşturduğunuz
+hesaplar, gerçek Apple ID değil; satın alma geçmişini temizlemek testte bir
+aboneliği yeniden satın alınabilir yapan şey ve testçiyi düzenlemekten ayrı bir
+çağrı.
+
+---
+
+### CI'da çalıştır
+
+[`ci/release-notes.yml`](ci/release-notes.yml) çalışan bir GitHub Actions
+workflow'u: bir ajan son tag'den beri gelen commit'leri okuyor, sürüm notu
+yazıyor ve App Store sürümünün "Yenilikler" alanına koyuyor.
+
+CI'da kimlik ve bayraklar için üç not:
+
+- **`ASC_PRIVATE_KEY` satır içi PEM olarak** buradaki doğru biçim. Runner'da
+  Keychain yok ve diskteki bir anahtar dosyası temizlenecek bir şey daha.
+- **`--no-confirm`** her yazma için gerekli, ve pervasız değil dürüst: istemi
+  cevaplayacak kullanıcı yok, yani varsayılan `strong` kapı yazmayı reddeder ve
+  bunu ret olarak bildirir. Takılıyormuş gibi görünmektense açıkça söyleyin.
+- **`--read-only`** yalnızca rapor üreten her iş için. Yazamayan bir iş yanlışlıkla
+  da yazamaz; bu, dikkatli bir istemden daha değerli.
+
+Önce hepsini **`--dry-run`** ile koşturun. Her yazma, doğrulamadan geçtikten
+sonra ne *gönderilecekti* onu döndürür — metot, yol, gövde, risk seviyesi — ve
+Apple'a hiçbir şey ulaşmaz.

--- a/examples/ci/release-notes.yml
+++ b/examples/ci/release-notes.yml
@@ -1,0 +1,97 @@
+# Write release notes into App Store Connect from CI.
+#
+# An agent reads the commits since the last tag, writes the "What's New" text,
+# and puts it on the App Store version — the one part of a release that is
+# prose, done by the thing that is good at prose, in the pipeline that already
+# knows what shipped.
+#
+# Run it manually first. `dry_run: true` is the default on purpose: every write
+# comes back as what WOULD have been sent (method, path, body, risk level)
+# after validation, and nothing reaches Apple. Read that output once before
+# trusting the real thing.
+name: Release notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'App Store version string (e.g. 3.2.0)'
+        required: true
+      locale:
+        description: 'Which localization to write'
+        default: en-US
+      dry_run:
+        description: 'Rehearse without sending anything to Apple'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  notes:
+    runs-on: ubuntu-latest
+    steps:
+      # The whole history, because the agent's first job is to read it: a
+      # shallow clone has no previous tag to diff against.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Collect what shipped
+        id: log
+        run: |
+          previous=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo '')
+          {
+            echo 'commits<<COMMITS_EOF'
+            if [ -n "$previous" ]; then
+              git log --no-merges --pretty='- %s' "$previous"..HEAD
+            else
+              git log --no-merges --pretty='- %s' -30
+            fi
+            echo 'COMMITS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Register the profile this job needs
+        # `distribution` alone: version localizations live there, and a job that
+        # cannot reach the pricing tools cannot touch a price by accident.
+        run: npx -y @erayendes/asc-mcp register distribution --clients=claude
+
+      - name: Write the release notes
+        env:
+          # An inline PEM is the right form on a runner. There is no Keychain
+          # here, and a key written to disk is one more thing to clean up on
+          # every exit path, including the ones that do not run.
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+          # No user is here to answer an elicitation prompt. Left at the default
+          # `strong`, the write would be refused and reported as a refusal —
+          # which reads, in a log, exactly like a bug. Saying so explicitly is
+          # the honest form.
+          ASC_CONFIRM_WRITES: '0'
+          ASC_DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          COMMITS: ${{ steps.log.outputs.commits }}
+        run: |
+          npx -y @anthropic-ai/claude-code \
+            --print \
+            --allowedTools 'mcp__asc-distribution__*' \
+            "Here are the commits since the last release:
+
+          $COMMITS
+
+          Write App Store release notes for version ${{ inputs.version }} of the
+          app in this account — user-facing, under 4000 characters, no commit
+          hashes, no internal ticket numbers, and nothing about refactors or
+          tests. Then put them in the whatsNew field of the ${{ inputs.locale }}
+          localization for that version.
+
+          Read before you write: find the version by its versionString, and
+          confirm it is still editable. A version already in review cannot be
+          changed, and reporting success on one that was not is worse than
+          failing."

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The examples are documentation that names things, which is the kind that
+ * rots quietly.
+ *
+ * `docs/GUIDE.md` carried "distribution … 129" through two releases where the
+ * real number was 130, and nothing noticed because prose has no tests. These
+ * assert the parts of examples/ that are claims about the code: profile names,
+ * tool counts, tool names, environment variables.
+ *
+ * Deliberately not asserted: the prose. A sentence that is wrong about how
+ * TestFlight works is a real defect and no test here would catch it — this
+ * covers the half that can be checked, and says so rather than implying the
+ * rest is verified.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { PROFILES, resolveSelection, toolCountFor } from '../src/profiles.js';
+import { OPERATIONS } from '../src/generated/operations.js';
+import { toolNameFor } from '../src/core/registry.js';
+
+const readme = readFileSync('examples/README.md', 'utf8');
+const workflow = readFileSync('examples/ci/release-notes.yml', 'utf8');
+
+/** Rows of the starter-pack tables: `| label | `a` + `b` | 187 |`. */
+const STARTER_ROWS = [...readme.matchAll(/^\| [^|]+ \| ((?:`[a-z:-]+`(?: \+ )?)+) \| (\d+) \|$/gm)];
+
+describe('the starter packs add up', () => {
+  it('finds rows to check at all', () => {
+    // Both language tables, seven packs each. A regex that silently matches
+    // nothing is a passing test that checks nothing.
+    expect(STARTER_ROWS.length).toBe(14);
+  });
+
+  it.each(STARTER_ROWS.map((m) => [m[1], Number(m[2])]))(
+    '%s serves %i tools',
+    (spec, claimed) => {
+      const total = String(spec)
+        .split(' + ')
+        .map((s) => s.replace(/`/g, ''))
+        .reduce((sum, name) => sum + toolCountFor(resolveSelection(name)), 0);
+      expect(total).toBe(claimed);
+    }
+  );
+});
+
+describe('everything the examples name exists', () => {
+  const profileNames = new Set(PROFILES.map((p) => p.name));
+
+  it('names only profiles that are real', () => {
+    const mentioned = new Set(
+      [...readme.matchAll(/`([a-z][a-z-]+)(?::[a-z,-]+)?`/g)]
+        .map((m) => m[1])
+        .filter((name) => profileNames.has(name) || name.includes('-'))
+    );
+    // Only the ones that look like profile names are checked; a word in
+    // backticks is not automatically a profile.
+    for (const name of mentioned) {
+      if (!profileNames.has(name) && PROFILES.some((p) => p.name.startsWith(name))) {
+        throw new Error(`"${name}" looks like a profile and is not one`);
+      }
+    }
+    expect(profileNames.has('distribution')).toBe(true);
+  });
+
+  it('names only tools that are served', () => {
+    const served = new Set([
+      ...OPERATIONS.map((op) => toolNameFor(op)),
+      // Hand-written tools are not in the generated catalogue.
+      'asc__status', 'asc__search_tools', 'asc__discover_domains', 'asc__call', 'asc__describe',
+      'asc__load', 'preflight__check_version', 'listing__get_screenshots',
+      'listing__upload_screenshot', 'analytics__get_report', 'reviews_ai__triage',
+      'reviews_ai__daily_briefing', 'reviews_ai__draft_response',
+      'pricing__get_subscription_price', 'pricing__set_subscription_price',
+      'pricing__equalize_price',
+    ]);
+    const named = [...readme.matchAll(/`([a-z_]+__[a-z_]+)`/g)].map((m) => m[1]);
+    expect(named.length).toBeGreaterThan(5);
+    for (const tool of named) {
+      expect(served.has(tool), `${tool} is named in examples/README.md and does not exist`).toBe(true);
+    }
+  });
+});
+
+describe('the CI example uses settings the server reads', () => {
+  const config = readFileSync('src/core/config.ts', 'utf8');
+
+  it.each(['ASC_KEY_ID', 'ASC_ISSUER_ID', 'ASC_PRIVATE_KEY', 'ASC_CONFIRM_WRITES', 'ASC_DRY_RUN'])(
+    '%s is a variable loadConfig looks at',
+    (name) => {
+      expect(workflow).toContain(name);
+      expect(config).toContain(name);
+    }
+  );
+
+  it('rehearses by default, so a first run cannot write to Apple', () => {
+    // The example's whole safety story. Someone who runs it to see what it does
+    // must not discover the answer on a live version.
+    expect(workflow).toMatch(/dry_run:[\s\S]*?default: true/);
+  });
+
+  it('turns confirmation off explicitly rather than leaving it to fail closed', () => {
+    // No user is present to answer an elicitation prompt, so the default gate
+    // would refuse the write and report a refusal — which reads like a bug.
+    expect(workflow).toContain("ASC_CONFIRM_WRITES: '0'");
+  });
+});


### PR DESCRIPTION
Closes MIL-172 and MIL-174.

### Starter packs (MIL-172)

The profile table was the only answer to "which profile do I install", and it is thirteen rows sorted by nothing in particular. There is a second answer now, by role:

| You are | Install | Tools |
|:--|:--|--:|
| Release manager | `distribution` + `app-info` | 187 |
| ASO / marketing | `marketing` + `analytics` | 123 |
| QA / TestFlight | `testflight` + `access` | 118 |
| Monetization | `monetization` | 206 |
| Game developer | `game-center` + `distribution` | 312 |
| Customer support | `monetization:storekit` | 18 |
| Build & signing | `provisioning` + `xcode-cloud` | 100 |

In `docs/GUIDE.md` and linked from the README, both languages. The ticket's list named `user-management`, which no longer exists — that profile is `access` now.

**The counts have a test.** `docs/GUIDE.md` carried "distribution … 129" through two releases where the real number was 130, and nothing noticed because prose has no tests. `tests/examples.test.ts` resolves every starter pack and asserts the arithmetic.

### `examples/` (MIL-174)

Seven scenarios, each naming the profile it needs and — more usefully — the part that usually goes wrong:

- **Sales/finance reports** — finance and sales are different reports, and "revenue" almost always means the first. They arrive as gzipped TSV; `parse=true` is what turns them into rows.
- **TestFlight invitations** — a tester belongs to the account before they belong to a group, and an external group needs Apple to review the build first. That is usually why testers "see nothing".
- **Version + build** — `preflight__check_version` answers the "what's missing" half in one call. A build still `PROCESSING` cannot be attached; an unanswered `usesNonExemptEncryption` parks the version at `WAITING_FOR_EXPORT_COMPLIANCE` with no explanation attached.
- **Review triage** — your model writes the replies, through your client's sampling. No second API key.
- **Keywords** — they live on the *version* localization, capped at 100 characters including commas. Name and subtitle live somewhere else entirely, because one belongs to the release and the other to the app.
- **Sandbox testers** — clearing purchase history is a separate call from editing the tester, and it is what makes a subscription purchasable again.
- **CI** — see below.

### `examples/ci/release-notes.yml` (the merged AI-180 scope)

A working GitHub Actions workflow: an agent reads the commits since the last tag, writes the "What's New" text, and puts it on the App Store version.

- **`dry_run: true` by default.** Someone who runs it to see what it does must not find out on a live version.
- **`ASC_CONFIRM_WRITES=0` set explicitly**, not left to fail closed. No user is present on a runner to answer an elicitation prompt, so the default `strong` gate would refuse the write and report a refusal — which reads, in a log, exactly like a bug.
- **`ASC_PRIVATE_KEY` as an inline PEM**, which is what the guide already recommends for CI: no Keychain on a runner, and a key on disk is one more thing to clean up on every exit path including the ones that do not run.
- **`register distribution` only** — a job that cannot reach the pricing tools cannot touch a price by accident.

### Testing

`tests/examples.test.ts` — 24 cases over profile names, starter-pack arithmetic, every tool name the examples cite, and the environment variables the CI example sets. Its header says plainly that the prose is *not* covered, rather than implying a green suite means the sentences are right.

563 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)