### PR TITLE
feat: ship a .mcpb bundle, for the menu ~/.claude.json cannot reach

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -166,6 +166,23 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: npm sbom --sbom-format spdx --omit=dev > "asc-mcp-${TAG}-sbom.spdx.json"
 
+      # The Claude app's Connectors menu is fed by MCPB bundles, not by
+      # ~/.claude.json, so this is the only route into it. Built here rather
+      # than committed: it is 3.7 MB of bundled server, and a copy in the repo
+      # would go stale the first time anyone forgot to rebuild it.
+      #
+      # Unsigned. `mcpb sign` wants a code-signing certificate this project does
+      # not carry, and an unsigned bundle installs behind a warning that says
+      # something true rather than not installing at all.
+      - name: Build the .mcpb bundle
+        # esbuild still ships a postinstall that fetches its platform binary,
+        # and `npm ci` above ran with --ignore-scripts for the SBOM. Rebuilding
+        # it here is cheaper than dropping that flag, which would let every
+        # dependency's install script run in a job that holds contents:write.
+        run: |
+          npm rebuild esbuild
+          npm run mcpb
+
       - name: Create GitHub release from the changelog
         env:
           GH_TOKEN: ${{ github.token }}
@@ -187,10 +204,11 @@ jobs:
           # Release immutability freezes assets at publish time, so the SBOM has
           # to go up with the release rather than being attached afterwards.
           sbom="asc-mcp-${TAG}-sbom.spdx.json"
+          bundle="dist-mcpb/heimdall-asc-${TAG#v}.mcpb"
 
           if [ -s /tmp/notes.md ]; then
-            gh release create "$TAG" --title "$TAG" --notes-file /tmp/notes.md "$sbom"
+            gh release create "$TAG" --title "$TAG" --notes-file /tmp/notes.md "$sbom" "$bundle"
           else
             echo "No changelog entry for $TAG — falling back to generated notes."
-            gh release create "$TAG" --title "$TAG" --generate-notes "$sbom"
+            gh release create "$TAG" --title "$TAG" --generate-notes "$sbom" "$bundle"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ keys/
 companies.json
 .DS_Store
 coverage/
+
+# The .mcpb bundle and its staging directory — built, never committed.
+dist-mcpb/
+
+# Only the hand-written manifest is source; the rest is assembled into dist-mcpb.
+mcpb/server/
+mcpb/skills/
+mcpb/package.json

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. The format is based on 
 ## English
 ### [Unreleased]
 
+#### A `.mcpb` bundle, for the menu `~/.claude.json` cannot reach
+Two registries exist and only one of them is a config file. Profiles registered by `setup` are what the agent and the CLI read; the Claude app's **Connectors** menu is fed by MCPB bundles instead, and a local server in `~/.claude.json` never appears there. So "it works but it is not in the menu" was not a bug to find — the menu was reading somewhere else the whole time.
+
+Every release now carries `heimdall-asc-<version>.mcpb`. Drag it onto Claude and a form asks for the profile and, if `setup` has not already run, the key details. The bundle carries the server and its dependencies inlined, so nothing on the machine needs Node.
+
+Two constraints stated rather than worked around. **One bundle serves one profile** — a bundle is one server and one toggle, which is MCPB's shape, not a decision here; installing it again adds another area. And **`setup` is still the better home for the key**: leave the credential fields empty and the bundle uses the shared config, with the `.p8` in the Keychain. Fill them in and the host stores the path instead — safely, but on disk.
+
+Unsigned, and the installer says so. Signing wants a code-signing certificate this project does not carry, and a warning that is true beats a bundle that will not install.
+
+While the manifest was being written, `package.json`'s own description turned out to claim **875 tools**. It is a fifth surface advertising the count and the release pre-flight checks four; it now says 884 like the others.
+
+
 #### Starter packs, and seven scenarios worked through
 "Which profile do I install?" had one answer and it was a table of thirteen rows sorted by nothing in particular. There is a second answer now, by role: a release manager installs `distribution` + `app-info`, an ASO team `marketing` + `analytics`, customer support `monetization:storekit` and eighteen tools. Seven packs, in the guide and in the README, with tool counts a test keeps honest — `docs/GUIDE.md` carried "distribution … 129" through two releases where the number was 130, because prose has no tests.
 
@@ -371,6 +383,18 @@ Safety and usability release: every write is now schema-checked locally, preview
 
 ## Türkçe
 ### [Unreleased]
+
+#### `~/.claude.json`'ın ulaşamadığı menü için bir `.mcpb` paketi
+İki kayıt sistemi var ve yalnızca biri bir yapılandırma dosyası. `setup`'ın kaydettiği profilleri ajan ve CLI okur; Claude uygulamasının **Connectors** menüsü ise MCPB paketlerinden beslenir ve `~/.claude.json`'daki yerel bir sunucu orada hiç görünmez. Yani "çalışıyor ama menüde yok" bulunacak bir hata değildi — menü baştan beri başka bir yeri okuyordu.
+
+Artık her sürüm `heimdall-asc-<sürüm>.mcpb` taşıyor. Claude'un üzerine sürükleyin; bir form profili ve `setup` çalışmadıysa anahtar bilgilerini sorar. Paket sunucuyu ve bağımlılıklarını içine gömülü taşır, yani makinede Node'a gerek yok.
+
+Etrafından dolaşılmayıp söylenen iki kısıt. **Bir paket bir profil sunar** — bir paket bir sunucu ve bir anahtar demek; bu MCPB'nin biçimi, burada verilmiş bir karar değil. Başka bir alan için tekrar kurun. Ve **anahtar için `setup` hâlâ daha iyi bir yer**: kimlik alanlarını boş bırakırsanız paket ortak yapılandırmayı kullanır, `.p8` Keychain'de kalır. Doldurursanız yolu bu kez host saklar — güvenli biçimde, ama diskte.
+
+İmzasız ve kurulum bunu söylüyor. İmzalamak bu projenin taşımadığı bir kod imzalama sertifikası ister; doğru olan bir uyarı, kurulamayan bir paketten iyidir.
+
+Manifest yazılırken `package.json`'ın kendi açıklamasının **875 araç** dediği ortaya çıktı. Sayıyı ilan eden beşinci yüzey ve yayın öncesi kontrolü dördünü denetliyor; artık o da diğerleri gibi 884 diyor.
+
 
 #### Başlangıç paketleri ve baştan sona işlenmiş yedi senaryo
 "Hangi profili kurayım?" sorusunun tek cevabı vardı ve o da özel bir sıraya göre dizilmemiş on üç satırlık bir tabloydu. Artık ikinci bir cevap var, role göre: yayın yöneticisi `distribution` + `app-info` kurar, ASO ekibi `marketing` + `analytics`, müşteri desteği `monetization:storekit` ve on sekiz araç. Yedi paket; rehberde ve README'de, araç sayılarını dürüst tutan bir testle birlikte — `docs/GUIDE.md` iki sürüm boyunca "distribution … 129" yazdı, doğrusu 130'du, çünkü düzyazının testi yok.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -132,6 +132,19 @@ npx -y @erayendes/asc-mcp monetization                       everything
 npx -y @erayendes/asc-mcp monetization:subscription-pricing  that slice plus core
 ```
 
+#### Or install it from the Connectors menu
+
+Two registries exist and only one of them is a config file. Profiles registered by `setup` are what the agent and the CLI read; the Claude app's **Connectors** menu is fed by MCPB bundles instead, and a local server in `~/.claude.json` does not appear there.
+
+[Releases](https://github.com/erayendes/app-store-connect-mcp/releases) carries a `.mcpb` for that menu. Download it, drag it onto Claude, and a form asks for the profile and — if you have not run `setup` — the key details. Nothing else is needed: the bundle carries the server and its dependencies, so no Node toolchain has to exist on the machine.
+
+Two things worth knowing before you choose this route:
+
+- **One bundle serves one profile.** That is an MCPB constraint rather than a decision: a bundle is one server and one toggle. Install it again to add another area.
+- **`setup` is still the better home for the key.** Leave the credential fields empty and the bundle uses the shared config `setup` wrote, with the `.p8` in the Keychain. Fill them in and the path to the key is stored by the host instead — safely, but on disk rather than in the Keychain.
+
+Build it yourself with `npm run mcpb`. The bundle is unsigned, so the installer says so; signing needs a code-signing certificate this project does not carry.
+
 #### Where it registers
 
 `setup` registers the profiles with every MCP client it finds. None of these clients share a config file, so this is the step that would otherwise be done once per client, by hand, in a different format each time.
@@ -502,6 +515,19 @@ Config'i elle yazacaksanız sözdizimi:
 npx -y @erayendes/asc-mcp monetization                       tamamı
 npx -y @erayendes/asc-mcp monetization:subscription-pricing  o dilim + çekirdek
 ```
+
+#### Ya da Connectors menüsünden kurun
+
+İki kayıt sistemi var ve yalnızca biri bir yapılandırma dosyası. `setup`'ın kaydettiği profilleri ajan ve CLI okur; Claude uygulamasının **Connectors** menüsü ise MCPB paketlerinden beslenir ve `~/.claude.json`'daki yerel bir sunucu orada görünmez.
+
+[Releases](https://github.com/erayendes/app-store-connect-mcp/releases) sayfasında o menü için bir `.mcpb` var. İndirin, Claude'un üzerine sürükleyin; bir form profili ve — `setup` çalıştırmadıysanız — anahtar bilgilerini sorar. Başka bir şey gerekmez: paket sunucuyu ve bağımlılıklarını taşır, yani makinede Node kurulu olmak zorunda değil.
+
+Bu yolu seçmeden önce bilinmesi gereken iki şey:
+
+- **Bir paket bir profil sunar.** Bu bir karar değil, MCPB kısıtı: bir paket bir sunucu ve bir anahtardır. Başka bir alan için tekrar kurun.
+- **Anahtar için `setup` hâlâ daha iyi bir yer.** Kimlik alanlarını boş bırakırsanız paket, `setup`'ın yazdığı ortak yapılandırmayı kullanır ve `.p8` Keychain'de kalır. Doldurursanız anahtarın yolunu bu kez host saklar — güvenli biçimde, ama Keychain'de değil diskte.
+
+Kendiniz derlemek için `npm run mcpb`. Paket imzasız, kurulum sırasında bunu söyler; imzalamak bu projenin taşımadığı bir kod imzalama sertifikası ister.
 
 #### Nereye kaydedilir
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/mcpb/main/schemas/mcpb-manifest-v0.4.schema.json",
+  "manifest_version": "0.4",
+  "name": "heimdall-asc",
+  "display_name": "Heimdall — App Store Connect",
+  "version": "2.2.0",
+  "description": "Every App Store Connect and StoreKit 2 endpoint, narrowed to the profile you pick.",
+  "long_description": "Heimdall serves the App Store Connect API and the App Store Server API (StoreKit 2), with every tool generated from Apple's own OpenAPI specification. Pick one profile at install time — distribution, monetization, marketing, testflight and nine more — and only that area's tools are served.\n\nThe key never leaves this machine: Heimdall reads it, signs a short-lived token, and talks to Apple directly. Nothing sits in between.\n\nIf you have already run `npx -y @erayendes/asc-mcp setup`, leave the credential fields below empty — the shared config it wrote is used instead, with the key still in the Keychain.",
+  "author": {
+    "name": "Eray Endes",
+    "url": "https://github.com/erayendes"
+  },
+  "homepage": "https://github.com/erayendes/app-store-connect-mcp",
+  "documentation": "https://github.com/erayendes/app-store-connect-mcp/blob/main/docs/GUIDE.md",
+  "support": "https://github.com/erayendes/app-store-connect-mcp/issues",
+  "license": "MIT",
+  "keywords": [
+    "app-store-connect",
+    "apple",
+    "storekit",
+    "testflight",
+    "ios"
+  ],
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/server/index.js",
+        "${user_config.profile}"
+      ],
+      "env": {
+        "ASC_KEY_ID": "${user_config.key_id}",
+        "ASC_ISSUER_ID": "${user_config.issuer_id}",
+        "ASC_PRIVATE_KEY_PATH": "${user_config.private_key_path}",
+        "ASC_VENDOR_NUMBER": "${user_config.vendor_number}",
+        "ASC_BUNDLE_ID": "${user_config.bundle_id}",
+        "ASC_READ_ONLY": "${user_config.read_only}"
+      }
+    }
+  },
+  "user_config": {
+    "profile": {
+      "type": "string",
+      "title": "Profile",
+      "description": "Which area of App Store Connect to serve. One bundle serves one profile; install it again with a different profile to add another.",
+      "default": "distribution",
+      "required": true
+    },
+    "key_id": {
+      "type": "string",
+      "title": "Key ID",
+      "description": "From App Store Connect → Users and Access → Integrations. Leave empty to use the credentials `asc-mcp setup` already wrote.",
+      "required": false
+    },
+    "issuer_id": {
+      "type": "string",
+      "title": "Issuer ID",
+      "description": "Shown above the key list on the same page. Leave empty to use the credentials `asc-mcp setup` already wrote.",
+      "required": false
+    },
+    "private_key_path": {
+      "type": "file",
+      "title": "Private key (.p8)",
+      "description": "The file Apple let you download exactly once. Heimdall reads it to sign a short-lived token; it is never sent anywhere. Leave empty if `asc-mcp setup` already put your key in the Keychain — that is the better place for it.",
+      "required": false,
+      "sensitive": true
+    },
+    "vendor_number": {
+      "type": "string",
+      "title": "Vendor number",
+      "description": "Only for sales and finance reports. Payments and Financial Reports → the number beside your legal entity.",
+      "required": false
+    },
+    "bundle_id": {
+      "type": "string",
+      "title": "Bundle ID",
+      "description": "Only for StoreKit 2 — customer transactions, entitlements and refunds. The App Store Server API is scoped to one app, so these tools appear only when this is set.",
+      "required": false
+    },
+    "read_only": {
+      "type": "boolean",
+      "title": "Read-only",
+      "description": "Serve only tools that cannot change anything. A server that cannot write cannot write by accident.",
+      "default": false,
+      "required": false
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
+    "runtimes": {
+      "node": ">=20.19.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "description": "Heimdall — MCP server for the Apple App Store Connect API and App Store Server API (StoreKit 2). 875 tools across 13 profiles, generated from Apple's official OpenAPI spec, plus review triage and reply drafting that runs on your own model, and confirm-before-write safety. Works with Claude, Codex, Cursor and any MCP client.",
+  "description": "Heimdall — MCP server for the Apple App Store Connect API and App Store Server API (StoreKit 2). 884 tools across 13 profiles, generated from Apple's official OpenAPI spec, plus review triage and reply drafting that runs on your own model, and confirm-before-write safety. Works with Claude, Codex, Cursor and any MCP client.",
   "author": {
     "name": "Eray Endeş",
     "email": "erayendes@gmail.com",
@@ -38,6 +38,7 @@
   ],
   "scripts": {
     "generate": "tsx scripts/generate.ts && tsx scripts/generate-profiles.ts",
+    "mcpb": "tsx scripts/build-mcpb.ts",
     "build": "npm run generate && tsc",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",

--- a/scripts/build-mcpb.ts
+++ b/scripts/build-mcpb.ts
@@ -1,0 +1,82 @@
+/**
+ * Builds the .mcpb bundle — Heimdall as one file a person double-clicks.
+ *
+ * Two registries exist and only one of them is `~/.claude.json`. Profiles added
+ * there work, and they do not appear in the Claude app's Connectors menu, which
+ * is fed by MCPB bundles and remote connectors instead. This is what puts
+ * Heimdall in that menu, with the credentials collected by a form rather than
+ * by a terminal.
+ *
+ * Everything is inlined by esbuild, dependencies included, so the bundle has no
+ * node_modules and needs no npx at run time. `package.json` and `skills/` are
+ * copied beside it because two modules resolve them relative to themselves:
+ * `VERSION` in server.ts and the packaged SKILL.md in skill.ts.
+ *
+ * One bundle serves one profile — that is an MCPB constraint, not a choice.
+ * A person who wants two areas installs it twice, which is why the profile is
+ * install-time configuration rather than something baked in here.
+ */
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { PROFILES } from '../src/profiles.js';
+
+/** Hand-written and version-controlled. Nothing writes back to it. */
+const SOURCE = 'mcpb/manifest.json';
+/** Staging: assembled fresh every run, ignored by git. */
+const OUT = 'dist-mcpb/bundle';
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+
+// The manifest is the one file that is hand-written and version-controlled, so
+// the version in it is a placeholder rather than a number to keep in step with
+// package.json by hand — that is the drift the release pre-flight exists for.
+const manifest = JSON.parse(readFileSync(SOURCE, 'utf8'));
+manifest.version = pkg.version;
+
+// MCPB's user_config has no enum, so the choice is a free-text field and the
+// valid values have to be in the prose. Generated from the code rather than
+// typed, because a profile renamed here and not there is an installer offering
+// something that no longer exists.
+manifest.user_config.profile.description =
+  `${manifest.user_config.profile.description} One of: ${PROFILES.map((p) => p.name).join(', ')}. ` +
+  `Narrow further with a colon, e.g. monetization:subscription-pricing.`;
+
+rmSync(OUT, { recursive: true, force: true });
+mkdirSync(join(OUT, 'server'), { recursive: true });
+
+execFileSync(
+  'npx',
+  [
+    'esbuild',
+    'src/index.ts',
+    '--bundle',
+    '--platform=node',
+    '--format=esm',
+    '--target=node20',
+    `--outfile=${join(OUT, 'server', 'index.js')}`,
+    // esbuild's ESM output keeps `require` calls from CommonJS dependencies,
+    // and ESM has no `require`. Without this the bundle throws on first import.
+    "--banner:js=import{createRequire as __mcpbRequire}from'node:module';const require=__mcpbRequire(import.meta.url);",
+  ],
+  { stdio: 'inherit' }
+);
+
+cpSync('skills', join(OUT, 'skills'), { recursive: true });
+// Only the fields the bundle actually reads. Shipping the whole file would put
+// devDependencies and scripts in front of anyone who opens the bundle.
+writeFileSync(
+  join(OUT, 'package.json'),
+  `${JSON.stringify({ name: pkg.name, version: pkg.version, type: pkg.type, license: pkg.license }, null, 2)}\n`
+);
+writeFileSync(join(OUT, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+
+const mcpb = (...args: string[]) =>
+  execFileSync('npx', ['--yes', '@anthropic-ai/mcpb', ...args], { stdio: 'inherit' });
+
+mcpb('validate', join(OUT, 'manifest.json'));
+mcpb('pack', OUT, `dist-mcpb/heimdall-asc-${pkg.version}.mcpb`);
+
+// Unsigned on purpose. `mcpb sign` wants a code-signing certificate, and an
+// unsigned bundle installs with a warning rather than not at all — a warning
+// that says what is true.
+console.log(`\ndist-mcpb/heimdall-asc-${pkg.version}.mcpb — drag it onto Claude to install.`);

--- a/tests/mcpb.test.ts
+++ b/tests/mcpb.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The MCPB manifest is a fifth place the same facts are written down.
+ *
+ * Two registries exist: `~/.claude.json`, which the agent reads, and the
+ * Claude app's Connectors menu, which is fed by MCPB bundles instead. The
+ * manifest is what puts Heimdall in the second one — and being hand-written
+ * and rarely opened, it is exactly the kind of file that goes on describing a
+ * flag that was renamed two releases ago.
+ *
+ * The version is not checked here: `scripts/build-mcpb.ts` stamps it from
+ * package.json at build time, so the placeholder in the source file is
+ * deliberate.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { PROFILES } from '../src/profiles.js';
+
+const manifest = JSON.parse(readFileSync('mcpb/manifest.json', 'utf8'));
+const config = readFileSync('src/core/config.ts', 'utf8');
+
+describe('the MCPB manifest describes this server', () => {
+  it('launches the bundled entry point rather than reaching for npx', () => {
+    // The whole point of a bundle is that it runs on a machine with no Node
+    // toolchain and no npm. `npx -y @erayendes/asc-mcp` here would work on the
+    // author's machine and nowhere else.
+    expect(manifest.server.mcp_config.command).toBe('node');
+    expect(manifest.server.mcp_config.args[0]).toContain('${__dirname}');
+    expect(JSON.stringify(manifest.server.mcp_config)).not.toContain('npx');
+  });
+
+  it('passes the profile as the positional argument the CLI takes', () => {
+    expect(manifest.server.mcp_config.args[1]).toBe('${user_config.profile}');
+    expect(manifest.user_config.profile.required).toBe(true);
+  });
+
+  it.each(Object.entries(manifest.server.mcp_config.env as Record<string, string>))(
+    '%s is a variable loadConfig reads',
+    (name, value) => {
+      expect(config, `${name} is set by the manifest and read by nothing`).toContain(name);
+      // Every one is fed by a user_config field; a hardcoded value here would
+      // be a setting nobody can change after install.
+      const key = /^\$\{user_config\.([a-z_]+)\}$/.exec(value)?.[1];
+      expect(key, `${name} is not wired to a user_config field`).toBeDefined();
+      expect(Object.keys(manifest.user_config)).toContain(key);
+    }
+  );
+
+  it('asks for nothing it cannot use', () => {
+    // Every field either feeds an env var or is the profile argument.
+    const wired = new Set(
+      Object.values(manifest.server.mcp_config.env as Record<string, string>)
+        .map((v) => /^\$\{user_config\.([a-z_]+)\}$/.exec(v)?.[1])
+        .filter(Boolean)
+    );
+    wired.add('profile');
+    expect(Object.keys(manifest.user_config).sort()).toEqual([...wired].sort());
+  });
+
+  it('marks the private key sensitive, so the host stores it in the keychain', () => {
+    // Heimdall's one promise about credentials is that the .p8 does not sit in
+    // a plain-text config. A manifest field that forgets this quietly breaks it.
+    expect(manifest.user_config.private_key_path.sensitive).toBe(true);
+  });
+
+  it('only requires what a server can actually start without', () => {
+    // The credential fields are optional on purpose: `asc-mcp setup` may have
+    // written them already, and asking twice for a key that is in the Keychain
+    // is how it ends up on disk instead.
+    const required = Object.entries(manifest.user_config)
+      .filter(([, field]) => (field as { required?: boolean }).required)
+      .map(([name]) => name);
+    expect(required).toEqual(['profile']);
+  });
+
+  it('claims a default profile that exists', () => {
+    expect(PROFILES.map((p) => p.name)).toContain(manifest.user_config.profile.default);
+  });
+});


### PR DESCRIPTION
Closes MIL-134.

Two registries exist and only one of them is a config file. Profiles registered by `setup` are what the agent and the CLI read; the Claude app's **Connectors** menu is fed by MCPB bundles instead, and a local server in `~/.claude.json` never appears there. "It works but it is not in the menu" was never a bug to find — the menu was reading somewhere else the whole time.

Every release now carries `heimdall-asc-<version>.mcpb`. Drag it onto Claude and a form asks for the profile and, if `setup` has not run, the key details. Dependencies are inlined by esbuild, so nothing on the target machine needs Node.

```
package size: 506.1 kB   unpacked: 3.7 MB   files: 4
```

### Option A from the ticket, and the two constraints stated rather than worked around

- **One bundle serves one profile.** A bundle is one server and one toggle — MCPB's shape, not a decision here. Installing it again adds another area. The ticket already called this out; nothing here changes it.
- **`setup` stays the better home for the key.** Leave the credential fields empty and the bundle uses the shared config, with the `.p8` in the Keychain. Fill them in and the host stores the path instead — safely, but on disk. The field is `sensitive: true` either way, and the description says which is better.

### Build

`npm run mcpb`, and in the release job after the SBOM. Built rather than committed: 3.7 MB of bundled server in the repo goes stale the first time someone forgets to rebuild it.

The manifest is hand-written and version-controlled; the build stamps the version and the profile list into a **staging copy**, so nothing writes back to the source. `user_config` has no `enum` — the schema rejects it — so the profile is a free-text field whose valid values are generated into its description from `PROFILES`. A profile renamed in the code cannot leave the installer offering one that does not exist.

The release job runs `npm rebuild esbuild` first: `npm ci --ignore-scripts` is already there for the SBOM, and esbuild still fetches its platform binary in a postinstall. Rebuilding one package is cheaper than dropping the flag in a job that holds `contents: write`.

**Unsigned.** `mcpb sign` wants a code-signing certificate this project does not carry. An unsigned bundle installs behind a warning that says something true, which beats one that will not install.

### Found on the way

`package.json`'s own description claimed **875 tools**. It is a fifth surface advertising the count and the release pre-flight checks four. Now 884, like the others.

### Verification

12 tests in `tests/mcpb.test.ts` over the manifest: that it launches the bundled entry point rather than reaching for `npx` (which would work on the author's machine and nowhere else), that every env var it sets is one `loadConfig` reads, that every `user_config` field is wired to something, that the key is marked sensitive, and that only the profile is required.

Built and run end to end locally — `--version`, `--help`, and an `initialize` handshake against `dist-mcpb/bundle/server/index.js`. **The GUI install is the one step I cannot do here**: drag `dist-mcpb/heimdall-asc-2.2.0.mcpb` onto Claude and check the form renders and the toggle appears.

575 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)