### PR TITLE
chore: prepare 2.3.0 — everything except the tag

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 repository-code: "https://github.com/erayendes/app-store-connect-mcp"
 url: "https://github.com/erayendes/app-store-connect-mcp"
 license: MIT
-version: 2.2.0
+version: 2.3.0
 date-released: "2026-08-13"
 keywords:
   - mcp

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 All notable changes to this project are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and the project follows [Semantic Versioning](https://semver.org/). Entries are newest-first.
 
 ## English
-### [Unreleased]
+### [2.3.0] — 2026-08-18
 
 #### `release__submit` — the three-step submission, in order, once
 Apple's names hide a dance. `review_submissions__create` takes an *app*, not a version, and makes an empty container. The version arrives as a separate item. And nothing reaches Apple until `submitted` is patched true. An agent that stops after the POST reports a release it did not ship — which is why those three descriptions were already worded to name the next call.
@@ -416,7 +416,7 @@ Safety and usability release: every write is now schema-checked locally, preview
 - AI-assisted review tools via MCP Sampling.
 
 ## Türkçe
-### [Unreleased]
+### [2.3.0] — 2026-08-18
 
 #### `release__submit` — üç adımlı gönderim, sırasıyla, tek seferde
 Apple'ın adlandırması bir dansı gizliyor. `review_submissions__create` sürümü değil *uygulamayı* alıyor ve boş bir kap yaratıyor. Sürüm ayrı bir öğe olarak geliyor. Ve `submitted` true'ya çekilene kadar Apple'a hiçbir şey ulaşmıyor. POST'tan sonra duran bir ajan, göndermediği bir yayını bildiriyor — o üç açıklamanın zaten bir sonraki çağrıyı adıyla söylemesinin sebebi bu.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@erayendes/asc-mcp",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@erayendes/asc-mcp",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@apple/app-store-server-library": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erayendes/asc-mcp",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "mcpName": "io.github.erayendes/asc-mcp",
   "publishConfig": {
     "access": "public"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/erayendes/app-store-connect-mcp",
     "source": "github"
   },
-  "version": "2.2.0",
+  "version": "2.3.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@erayendes/asc-mcp",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
**Not to be merged without a word from you.** Merging this and pushing `v2.3.0` is what publishes to npm, the MCP Registry and a GitHub release. Everything mechanical is done so that decision is the only thing left.

### What is in 2.3.0 — eight commits since v2.2.0

| PR | |
|:--|:--|
| #74 | `preflight__check_version` — "can this version be submitted", in one call |
| #75 | A write says which app it is about to change; the 46 app-rooted tools take a name or bundle ID |
| #76 | `asc__account_status`, `listing__diff_metadata`, and MCP prompts |
| #77 | Search ranking **83 → 143** of 265 measured phrasings |
| #78 | Starter packs by role, `examples/`, a GitHub Actions workflow |
| #79 | A `.mcpb` bundle for the Connectors menu |
| #80 | `metadata_ai__*` — three tools that never write on their own judgement |
| #81 | `release__submit` — the three-step submission, in order, once |

Two of them fix things that look like bugs from the outside: a confirmation prompt that waited **49 seconds** before appearing and then showed a raw id, and a search ranking where the tool a query was about came fourth behind its own sub-resources.

### Pre-flight, run locally against the publish workflow's own script

```
All versions agree on 2.3.0, 890 tools everywhere, and the changelog has a heading for it.
```

- `npm run generate` produces no diff
- 631 tests passing
- the release-notes `awk` extracts 103 lines for `### [2.3.0]`, so the GitHub release carries the bilingual changelog rather than falling back to raw commit titles
- `server.json` description is 86 characters, under the registry's 100

### What merging + tagging does

```bash
git checkout main && git pull
git tag -a v2.3.0 -m "v2.3.0" && git push origin v2.3.0
```

The Publish workflow takes it from there: npm with provenance via trusted publishing, the MCP Registry, and a GitHub release with an SPDX SBOM and the `.mcpb` bundle attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)