### PR TITLE
feat: an opt-in probe for what this API key can actually reach

### DIFF
--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -63,6 +63,16 @@ export const META_TOOLS: McpToolDefinition[] = [
             'Also list signing certificates and provisioning profiles expiring within 30 days ' +
             '(two extra API calls; default false).',
         },
+        check_capabilities: {
+          type: 'boolean',
+          description:
+            'Also report what this API key can reach, by probing one cheap endpoint per role ' +
+            'family (reports, metadata, reviews, user management, provisioning) and recording ' +
+            'ok/forbidden/unauthorized per family — never the role name itself, which no ' +
+            'endpoint returns. Up to five extra API calls, fewer when check_connection or ' +
+            'check_expirations already covered part of it; default false. Call this once, ' +
+            'before relying on a family, rather than discovering the gap from a 403 mid-task.',
+        },
       },
     },
     annotations: { readOnlyHint: true },
@@ -262,6 +272,125 @@ export function summarizeExpirations(
   };
 }
 
+/**
+ * What one capability probe found. `unknown` covers every case where the
+ * probe cannot speak to permission at all — a network failure, a 5xx, or (for
+ * an app-scoped family) no app to run it against — which is deliberately
+ * indistinguishable from a slow API. Collapsing that into `forbidden` is the
+ * one mistake this has to never make: it would tell a working key to go
+ * through setup again for no reason.
+ */
+export type ProbeState = 'ok' | 'forbidden' | 'unauthorized' | 'unknown';
+
+/**
+ * Apple's role split does not line up with the shape of the work: the
+ * Analytics Reports API answers only to Admin, Finance or Sales (Access to
+ * Reports), first requesting a report type is Admin-only with no path to it
+ * in the App Store Connect UI, and metadata plus customer reviews want Admin
+ * or App Manager. None of that is in any response body — a role is chosen
+ * when a team key is created and never read back, and an individual key
+ * silently inherits its creator's roles and app restrictions. So a session
+ * only learns its key is narrow when a 403 lands mid-task, and reads that as
+ * the tool being broken rather than the key being scoped. This is the probe:
+ * one cheap GET per family, asked once, up front.
+ */
+function classifyProbe(err: unknown): ProbeState {
+  const status = (err as { status?: number } | undefined)?.status;
+  if (status === 401) return 'unauthorized';
+  if (status === 403) return 'forbidden';
+  // status 0 is a network failure that never reached Apple; anything else
+  // (5xx, an unrecognised shape) is inconclusive rather than a denial.
+  return 'unknown';
+}
+
+async function probeFamily(http: AscHttpClient, path: string): Promise<ProbeState> {
+  try {
+    await http.get(path, { limit: 1 });
+    return 'ok';
+  } catch (err) {
+    return classifyProbe(err);
+  }
+}
+
+export interface CapabilityReport {
+  baseline: ProbeState;
+  reports: ProbeState;
+  metadata: ProbeState;
+  reviews: ProbeState;
+  userManagement: ProbeState;
+  provisioning: ProbeState;
+  summary: string;
+}
+
+function summarizeCapabilities(states: Omit<CapabilityReport, 'summary'>): string {
+  const families: Array<[string, ProbeState]> = [
+    ['reports', states.reports],
+    ['metadata', states.metadata],
+    ['reviews', states.reviews],
+    ['user management', states.userManagement],
+    ['provisioning', states.provisioning],
+  ];
+  const denied = families.filter(([, s]) => s === 'forbidden').map(([n]) => n);
+  const unclear = families.filter(([, s]) => s === 'unknown').map(([n]) => n);
+
+  const parts: string[] = [];
+  parts.push(
+    denied.length ? `no access to ${denied.join(', ')}` : 'no denials among the families probed'
+  );
+  if (unclear.length) parts.push(`${unclear.join(', ')} inconclusive — re-run to be sure`);
+  return `${parts.join('; ')}.`;
+}
+
+/**
+ * Runs the five family probes and folds in whatever the caller already knows
+ * from `check_connection` (the baseline call) and `check_expirations` (the
+ * certificates call) so `check_capabilities` never repeats a request the same
+ * `asc__status` call already made.
+ *
+ * A baseline of `unauthorized` short-circuits: the key itself is not
+ * authenticating, so every family probe would fail the same way for the same
+ * reason, and running five more requests to confirm that once each spends
+ * calls to learn nothing new.
+ */
+export async function probeCapabilities(
+  http: AscHttpClient,
+  baseline: ProbeState,
+  appId: string | undefined,
+  certificatesProbe?: ProbeState
+): Promise<CapabilityReport> {
+  if (baseline === 'unauthorized') {
+    const states = {
+      baseline,
+      reports: 'unauthorized' as const,
+      metadata: 'unauthorized' as const,
+      reviews: 'unauthorized' as const,
+      userManagement: 'unauthorized' as const,
+      provisioning: 'unauthorized' as const,
+    };
+    return {
+      ...states,
+      summary: 'The API key itself is not authenticating; nothing else was probed.',
+    };
+  }
+
+  // App-scoped families have nothing to probe without an app id — that is
+  // itself the "no app to cover the probe" case `unknown` exists for, not a
+  // reason to guess.
+  const appScoped = (path: string) =>
+    appId ? probeFamily(http, path) : Promise.resolve<ProbeState>('unknown');
+
+  const [reports, metadata, reviews, userManagement, provisioning] = await Promise.all([
+    appScoped(`/v1/apps/${encodeURIComponent(appId ?? '')}/analyticsReportRequests`),
+    appScoped(`/v1/apps/${encodeURIComponent(appId ?? '')}/appInfos`),
+    appScoped(`/v1/apps/${encodeURIComponent(appId ?? '')}/customerReviews`),
+    probeFamily(http, '/v1/users'),
+    certificatesProbe ?? probeFamily(http, '/v1/certificates'),
+  ]);
+
+  const states = { baseline, reports, metadata, reviews, userManagement, provisioning };
+  return { ...states, summary: summarizeCapabilities(states) };
+}
+
 export async function executeMetaTool(
   name: string,
   args: Record<string, unknown>,
@@ -425,6 +554,9 @@ export async function executeMetaTool(
 
     case 'asc__status': {
       const checkConnection = args.check_connection !== false;
+      const checkExpirations = args.check_expirations === true;
+      const checkCapabilities = args.check_capabilities === true;
+
       const result: Record<string, unknown> = {
         specVersion: SPEC_VERSION,
         loadedDomains: ctx.loadedDomains,
@@ -438,19 +570,37 @@ export async function executeMetaTool(
         rateLimit: ctx.http.limiter.status(),
       };
 
-      if (checkConnection) {
+      // check_capabilities' baseline probe and check_connection's own check
+      // are the same request (GET /v1/apps?limit=1), so this runs it once for
+      // either or both — and is where the capability probes get the app id
+      // they scope three of the five families to.
+      let appId: string | undefined;
+      let baselineProbe: ProbeState | undefined;
+      if (checkConnection || checkCapabilities) {
         try {
           const res: any = await ctx.http.get('/v1/apps', { limit: 1 });
-          result.connection = {
-            ok: true,
-            appsVisible: res?.meta?.paging?.total ?? res?.data?.length ?? 0,
-          };
+          appId = res?.data?.[0]?.id;
+          baselineProbe = 'ok';
+          if (checkConnection) {
+            result.connection = {
+              ok: true,
+              appsVisible: res?.meta?.paging?.total ?? res?.data?.length ?? 0,
+            };
+          }
         } catch (err) {
-          result.connection = { ok: false, error: (err as Error).message };
+          baselineProbe = classifyProbe(err);
+          if (checkConnection) {
+            result.connection = { ok: false, error: (err as Error).message };
+          }
         }
       }
 
-      if (args.check_expirations === true) {
+      // Certificates are fetched here (limit 200) when expirations were
+      // asked for; check_capabilities' provisioning probe below reuses this
+      // outcome instead of firing its own limit:1 request at the same
+      // endpoint.
+      let certificatesProbe: ProbeState | undefined;
+      if (checkExpirations) {
         // Two extra calls, so opt-in only. A key without the provisioning role
         // gets a 403 here — report it instead of failing the whole status.
         try {
@@ -458,10 +608,24 @@ export async function executeMetaTool(
             ctx.http.get<any>('/v1/certificates', { limit: 200 }),
             ctx.http.get<any>('/v1/profiles', { limit: 200 }),
           ]);
+          certificatesProbe = 'ok';
           result.expirations = summarizeExpirations(certs?.data ?? [], profiles?.data ?? []);
         } catch (err) {
+          certificatesProbe = classifyProbe(err);
           result.expirations = { error: (err as Error).message };
         }
+      }
+
+      if (checkCapabilities) {
+        // baselineProbe is always set by this point: the block above runs
+        // whenever checkCapabilities is true, whether or not checkConnection
+        // is also true.
+        result.capabilities = await probeCapabilities(
+          ctx.http,
+          baselineProbe!,
+          appId,
+          certificatesProbe
+        );
       }
 
       return result;

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -4,7 +4,9 @@ import {
   executeMetaTool,
   searchOperations,
   summarizeExpirations,
+  probeCapabilities,
 } from '../src/tools/meta.js';
+import { AscApiError } from '../src/core/errors.js';
 
 const DAY = 86_400_000;
 
@@ -184,5 +186,164 @@ describe('short tokens do not match mid-word', () => {
       // Also alongside real words, where the token has to survive scoring too.
       expect(() => searchOperations(`price ${token} app`), JSON.stringify(token)).not.toThrow();
     }
+  });
+});
+
+/**
+ * check_capabilities: one cheap probe per role family, because Apple never
+ * says which role a key has. A team key's role is picked at creation and
+ * never read back; an individual key silently inherits its creator's roles
+ * and app restrictions. So the only honest way to answer "can this key do X"
+ * is to try X cheaply and see what comes back — never to guess from a name.
+ */
+describe('asc__status check_capabilities', () => {
+  const baseCtx = (http: any): any => ({
+    registry: { get: () => undefined, size: 0, unloadedDomains: () => [] },
+    http,
+    tokens: { status: () => ({}) },
+    readOnly: false,
+    loadedDomains: [],
+  });
+
+  /**
+   * An `AscHttpClient`-shaped fake: `.get` answers per exact path and records
+   * every path it saw, `.limiter` satisfies the `rateLimit` field every
+   * `asc__status` call reads regardless of which flags are set.
+   */
+  function fakeHttp(answer: (path: string) => unknown): { get: any; limiter: any; calls: string[] } {
+    const calls: string[] = [];
+    return {
+      calls,
+      limiter: { status: () => ({}) },
+      get: async (path: string) => {
+        calls.push(path);
+        const result = answer(path);
+        if (result instanceof Error) throw result;
+        return result;
+      },
+    };
+  }
+
+  const appsOk = { data: [{ id: 'app-1' }] };
+  const ok = () => ({ data: [] });
+  const forbidden = () => new AscApiError('forbidden', 403);
+  const unauthorized = () => new AscApiError('unauthorized', 401);
+  const networkError = () => new AscApiError('Network error: fetch failed', 0);
+  const serverError = () => new AscApiError('server error', 503);
+
+  it('reports each of the four states, read straight off the probe', async () => {
+    const http = fakeHttp((path) => {
+      if (path.endsWith('/analyticsReportRequests')) return forbidden();
+      if (path.endsWith('/appInfos')) return unauthorized();
+      if (path.endsWith('/customerReviews')) return networkError();
+      if (path === '/v1/users') return ok();
+      if (path === '/v1/certificates') return serverError();
+      return ok();
+    });
+    const report = await probeCapabilities(http as any, 'ok', 'app-1');
+    expect(report.reports).toBe('forbidden');
+    expect(report.metadata).toBe('unauthorized');
+    // Network failure — must never read as forbidden. This is the one
+    // mistake that would send a working key back through setup for nothing.
+    expect(report.reviews).toBe('unknown');
+    expect(report.userManagement).toBe('ok');
+    // A 5xx is inconclusive, same bucket as a network failure.
+    expect(report.provisioning).toBe('unknown');
+  });
+
+  it('never calls a family probe forbidden because the network failed', async () => {
+    // Same case as above, isolated: every family probe fails at the
+    // transport layer, and every single one must land on unknown.
+    const http = fakeHttp(() => networkError());
+    const report = await probeCapabilities(http as any, 'ok', 'app-1');
+    for (const family of ['reports', 'metadata', 'reviews', 'userManagement', 'provisioning'] as const) {
+      expect(report[family], family).toBe('unknown');
+    }
+  });
+
+  it('short-circuits on an unauthorized baseline: nothing else is probed', async () => {
+    const http = fakeHttp(() => ok());
+    const report = await probeCapabilities(http as any, 'unauthorized', undefined);
+    expect(report.reports).toBe('unauthorized');
+    expect(report.metadata).toBe('unauthorized');
+    expect(report.reviews).toBe('unauthorized');
+    expect(report.userManagement).toBe('unauthorized');
+    expect(report.provisioning).toBe('unauthorized');
+    expect(report.summary).toMatch(/key itself is not authenticating/);
+    // The whole point of the short circuit: five calls that would all fail
+    // the same way for the same reason are never made.
+    expect(http.calls).toEqual([]);
+  });
+
+  it('marks the app-scoped families unknown, not forbidden, when there is no app to probe', async () => {
+    // A baseline that answers ok with zero apps in the account (or that
+    // itself came back forbidden/unknown) leaves no app id. That is exactly
+    // the "no app to cover the probe" shape unknown exists for.
+    const http = fakeHttp((path) => {
+      if (path === '/v1/users' || path === '/v1/certificates') return ok();
+      throw new Error('an app-scoped family was probed with no app id');
+    });
+    const report = await probeCapabilities(http as any, 'ok', undefined);
+    expect(report.reports).toBe('unknown');
+    expect(report.metadata).toBe('unknown');
+    expect(report.reviews).toBe('unknown');
+    expect(report.userManagement).toBe('ok');
+    expect(report.provisioning).toBe('ok');
+  });
+
+  it('reuses a certificates probe already made for check_expirations', async () => {
+    const http = fakeHttp((path) => {
+      if (path === '/v1/certificates') throw new Error('provisioning re-fetched certificates');
+      return ok();
+    });
+    const report = await probeCapabilities(http as any, 'ok', 'app-1', 'forbidden');
+    expect(report.provisioning).toBe('forbidden');
+    expect(http.calls).not.toContain('/v1/certificates');
+  });
+
+  it('does not fire a single probe when the flag is off', async () => {
+    const http = fakeHttp(() => appsOk);
+    const res: any = await executeMetaTool(
+      'asc__status',
+      { check_connection: false },
+      baseCtx(http)
+    );
+    expect(res.capabilities).toBeUndefined();
+    expect(http.calls).toEqual([]);
+  });
+
+  it('shares the baseline call with check_connection instead of asking twice', async () => {
+    const http = fakeHttp((path) => (path === '/v1/apps' ? appsOk : ok()));
+    const res: any = await executeMetaTool(
+      'asc__status',
+      { check_capabilities: true },
+      baseCtx(http)
+    );
+    expect(res.connection.ok).toBe(true);
+    expect(res.capabilities.baseline).toBe('ok');
+    expect(http.calls.filter((p) => p === '/v1/apps')).toHaveLength(1);
+  });
+
+  it('shares the certificates call with check_expirations instead of asking twice', async () => {
+    const http = fakeHttp((path) => {
+      if (path === '/v1/apps') return appsOk;
+      if (path === '/v1/certificates') return { data: [] };
+      if (path === '/v1/profiles') return { data: [] };
+      return ok();
+    });
+    const res: any = await executeMetaTool(
+      'asc__status',
+      { check_expirations: true, check_capabilities: true },
+      baseCtx(http)
+    );
+    expect(res.expirations.summary).toBeDefined();
+    expect(res.capabilities.provisioning).toBe('ok');
+    expect(http.calls.filter((p) => p === '/v1/certificates')).toHaveLength(1);
+  });
+
+  it('stays a read-only tool with the new flag added', () => {
+    const status = META_TOOLS.find((t) => t.name === 'asc__status')!;
+    expect(status.annotations?.readOnlyHint).toBe(true);
+    expect((status.inputSchema.properties as any).check_capabilities.type).toBe('boolean');
   });
 });


### PR DESCRIPTION
## What changes, and why

Apple never returns a key's role from any endpoint — a team key's role is picked at creation and never read back, an individual key silently inherits its creator's roles and app restrictions — so a session only learns its key is narrow when a 403 lands mid-task. `asc__status` gets a fourth opt-in flag, `check_capabilities`, following `check_expirations`'s shape exactly: off by default, and when on it fires one cheap GET per role family and reports `ok / forbidden / unauthorized / unknown` — never a guessed role name.

## Related issue

Part of the least-privilege work (H1 of 2); H2 documents how to read it, in a follow-up PR after this merges.

## Design notes

- **Shared calls, not doubled.** The capability baseline reuses `check_connection`'s own `GET /v1/apps?limit=1` (and is where the three app-scoped families get their app id from). The provisioning probe reuses `check_expirations`'s `GET /v1/certificates` when both flags are set together.
- **`unknown` is deliberately wide.** A network failure (status 0), a 5xx, and an app-scoped family with no app to run against are all `unknown`, never `forbidden` — misreading any of those as a denial would send a working key back through setup for nothing.
- **401 on the baseline short-circuits** the other five probes: they would all fail the same way for the same reason, so running them anyway spends calls to learn nothing new.
- **No `consistentWith` role inference.** The ticket called it optional; a guessed role name is exactly the kind of claim this feature exists to avoid making.

## Checklist

- [x] `npm test` and `npm run typecheck` pass
- [x] Generator touched? No — `src/generated/` is untouched
- [x] Descriptions or tool surface touched? No tool name, description or profile membership changed, so AX ceilings are unaffected
- [x] Docs updated if behaviour changed — behaviour is new but opt-in and self-describing via the tool schema; H2 adds the least-privilege write-up
- [x] No credentials, private keys, or real App Store Connect identifiers in the diff

## Tool count / AX impact

No change — 692/859 findability, same as before. One parameter added to an existing hand-written tool, not a new tool or generated operation.

## How this was verified

`npm run build && npm test` — 639 passed, 9 skipped, 43 files. `npm run typecheck` clean. `npm run ax:report` shows no drift. 9 new tests in `tests/meta.test.ts`: each of the four states, network failures never misread as forbidden, the 401 short circuit making zero extra calls, missing-app-id yielding `unknown`, both shared-call cases, the off-by-default request count, and the schema staying read-only.

---
_Generated by Claude Code_