### PR TITLE
fix: tell an unsigned agreement apart from a narrow API key

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -26,6 +26,24 @@ export class AscApiError extends Error {
     this.name = 'AscApiError';
   }
 
+  /**
+   * Whether Apple refused because a legal agreement is unsigned rather than
+   * because the key is scoped too narrowly. The two arrive as the same 403 and
+   * lead opposite ways: one is fixed by the Account Holder accepting terms on
+   * the developer website, the other by a role or a new key. Guessing wrong
+   * costs an afternoon of rotating credentials that were never the problem.
+   *
+   * Apple has no endpoint that reports agreement state — `/v1/agreements` was
+   * removed — so this error code is the only signal there is, and it only
+   * appears once the grace period is over.
+   */
+  get requiresAgreement(): boolean {
+    return (
+      this.status === 403 &&
+      this.errors.some((e) => String(e.code ?? '').startsWith('FORBIDDEN.REQUIRED_AGREEMENTS'))
+    );
+  }
+
   /** A short, human-readable explanation suitable for showing to the caller. */
   get summary(): string {
     if (this.errors.length === 0) return this.message;

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -413,6 +413,23 @@ export const STATUS_HINTS: Record<number, string> = {
     'may be sharing this API key.',
 };
 
+/**
+ * The other 403. Apple returns the same status for "your key is scoped too
+ * narrowly" and "nobody signed the current agreement", and the generic hint
+ * sends the second case hunting through roles and fresh API keys — none of
+ * which can fix it, because the block is on the account and not on the key.
+ *
+ * Only the Account Holder can clear it, only on the developer website, and
+ * the "Agreements, Tax, and Banking" page in App Store Connect is a different
+ * agreement that looks like the right place and is not.
+ */
+export const AGREEMENT_HINT =
+  'This is not a permissions problem and a new API key will not fix it: the account has an ' +
+  'unsigned or expired agreement. Only the Account Holder can accept it, by signing in at ' +
+  'https://developer.apple.com/account and agreeing to the current Program License Agreement ' +
+  '(the "Agreements, Tax, and Banking" page in App Store Connect is a different agreement). ' +
+  'Every App Store Connect API call stays blocked until then.';
+
 async function toApiError(res: Response): Promise<AscApiError> {
   let errors: AscApiErrorDetail[] = [];
   let message = `App Store Connect API returned ${res.status}`;
@@ -430,7 +447,12 @@ async function toApiError(res: Response): Promise<AscApiError> {
     // Non-JSON error body; the status line is all we have.
   }
 
-  const hint = STATUS_HINTS[res.status];
+  // The agreement 403 is answered before the generic one: same status, and
+  // the generic text would send the reader to the roles that cannot fix it.
+  const agreement = errors.some((e) =>
+    String(e.code ?? '').startsWith('FORBIDDEN.REQUIRED_AGREEMENTS')
+  );
+  const hint = agreement ? AGREEMENT_HINT : STATUS_HINTS[res.status];
   if (hint) message += `. ${hint}`;
 
   return new AscApiError(

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -10,6 +10,7 @@ import { STOREKIT_TOOLS } from '../storekit/index.js';
 import { PRICING_TOOLS } from './pricing.js';
 import { SCREENSHOT_TOOLS } from './screenshots.js';
 import type { AscHttpClient } from '../core/http.js';
+import { AscApiError } from '../core/errors.js';
 import type { TokenProvider } from '../core/jwt.js';
 
 export const META_TOOLS: McpToolDefinition[] = [
@@ -280,7 +281,7 @@ export function summarizeExpirations(
  * one mistake this has to never make: it would tell a working key to go
  * through setup again for no reason.
  */
-export type ProbeState = 'ok' | 'forbidden' | 'unauthorized' | 'unknown';
+export type ProbeState = 'ok' | 'forbidden' | 'unauthorized' | 'agreement' | 'unknown';
 
 /**
  * Apple's role split does not line up with the shape of the work: the
@@ -297,11 +298,17 @@ export type ProbeState = 'ok' | 'forbidden' | 'unauthorized' | 'unknown';
 function classifyProbe(err: unknown): ProbeState {
   const status = (err as { status?: number } | undefined)?.status;
   if (status === 401) return 'unauthorized';
+  // An unsigned agreement is a 403 too, and reporting it as a narrow key is
+  // the one wrong answer that costs a credential rotation to disprove.
+  if (err instanceof AscApiError && err.requiresAgreement) return 'agreement';
   if (status === 403) return 'forbidden';
   // status 0 is a network failure that never reached Apple; anything else
   // (5xx, an unrecognised shape) is inconclusive rather than a denial.
   return 'unknown';
 }
+
+/** Exported for the test: the classification is the decision worth pinning. */
+export const classifyProbeForTest = classifyProbe;
 
 async function probeFamily(http: AscHttpClient, path: string): Promise<ProbeState> {
   try {
@@ -331,9 +338,16 @@ function summarizeCapabilities(states: Omit<CapabilityReport, 'summary'>): strin
     ['provisioning', states.provisioning],
   ];
   const denied = families.filter(([, s]) => s === 'forbidden').map(([n]) => n);
+  const blocked = families.filter(([, s]) => s === 'agreement').map(([n]) => n);
   const unclear = families.filter(([, s]) => s === 'unknown').map(([n]) => n);
 
   const parts: string[] = [];
+  if (blocked.length) {
+    parts.push(
+      `${blocked.join(', ')} blocked by an unsigned or expired agreement, which only the ` +
+        'Account Holder can accept at https://developer.apple.com/account'
+    );
+  }
   parts.push(
     denied.length ? `no access to ${denied.join(', ')}` : 'no denials among the families probed'
   );
@@ -358,18 +372,23 @@ export async function probeCapabilities(
   appId: string | undefined,
   certificatesProbe?: ProbeState
 ): Promise<CapabilityReport> {
-  if (baseline === 'unauthorized') {
+  if (baseline === 'unauthorized' || baseline === 'agreement') {
     const states = {
       baseline,
-      reports: 'unauthorized' as const,
-      metadata: 'unauthorized' as const,
-      reviews: 'unauthorized' as const,
-      userManagement: 'unauthorized' as const,
-      provisioning: 'unauthorized' as const,
+      reports: baseline,
+      metadata: baseline,
+      reviews: baseline,
+      userManagement: baseline,
+      provisioning: baseline,
     };
     return {
       ...states,
-      summary: 'The API key itself is not authenticating; nothing else was probed.',
+      summary:
+        baseline === 'agreement'
+          ? 'The account has an unsigned or expired agreement, so every family is blocked for ' +
+            'that reason and none was probed. Only the Account Holder can accept it, at ' +
+            'https://developer.apple.com/account — the key and its roles are not the problem.'
+          : 'The API key itself is not authenticating; nothing else was probed.',
     };
   }
 

--- a/tests/agreement-403.test.ts
+++ b/tests/agreement-403.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The other 403.
+ *
+ * Apple answers "your key is scoped too narrowly" and "nobody has signed the
+ * current agreement" with the same status, and the two lead opposite ways: one
+ * is fixed by a role or a new key, the other only by the Account Holder
+ * accepting terms on the developer website. Sending the second case to the
+ * first answer costs an afternoon of rotating credentials that were never the
+ * problem — and it is a case every account meets, because Apple ships a new
+ * agreement roughly twice a year and blocks the API when the grace period ends.
+ *
+ * There is no endpoint that reports agreement state (`/v1/agreements` was
+ * removed), so this error code is the only signal that exists.
+ */
+import { describe, it, expect } from 'vitest';
+import { AscApiError } from '../src/core/errors.js';
+import { AGREEMENT_HINT, STATUS_HINTS } from '../src/core/http.js';
+import { classifyProbeForTest, probeCapabilities, type ProbeState } from '../src/tools/meta.js';
+
+const agreementError = () =>
+  new AscApiError('App Store Connect API returned 403', 403, [
+    {
+      code: 'FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED',
+      title: 'A required agreement is missing or has expired.',
+      detail: 'This request requires an in-effect agreement that has not been signed or has expired.',
+    },
+  ]);
+
+const roleError = () =>
+  new AscApiError('App Store Connect API returned 403', 403, [
+    { code: 'FORBIDDEN_ERROR', title: 'This request is forbidden for security reasons' },
+  ]);
+
+describe('AscApiError.requiresAgreement', () => {
+  it('recognises the agreement refusal', () => {
+    expect(agreementError().requiresAgreement).toBe(true);
+  });
+
+  it('does not claim it for an ordinary 403, which is the expensive confusion', () => {
+    expect(roleError().requiresAgreement).toBe(false);
+  });
+
+  it('does not claim it for a 401, where the key itself is the problem', () => {
+    const unauthorized = new AscApiError('unauthorized', 401, [
+      { code: 'FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED' },
+    ]);
+    expect(unauthorized.requiresAgreement).toBe(false);
+  });
+});
+
+describe('the hint a reader acts on', () => {
+  it('names the Account Holder, the developer website, and that a new key will not help', () => {
+    expect(AGREEMENT_HINT).toMatch(/Account Holder/);
+    expect(AGREEMENT_HINT).toMatch(/developer\.apple\.com\/account/);
+    expect(AGREEMENT_HINT).toMatch(/new API key will not fix it/i);
+  });
+
+  it('warns off the page that looks right and is not', () => {
+    // "Agreements, Tax, and Banking" in App Store Connect is the Paid Apps
+    // agreement — a different document, and the usual wrong turn.
+    expect(AGREEMENT_HINT).toMatch(/Agreements, Tax, and Banking/);
+  });
+
+  it('is not the roles hint, which would send the reader the wrong way', () => {
+    expect(AGREEMENT_HINT).not.toBe(STATUS_HINTS[403]);
+    expect(STATUS_HINTS[403]).toMatch(/role/i);
+  });
+});
+
+describe('capability probing', () => {
+  it('classifies the agreement 403 apart from a scoped key', () => {
+    expect(classifyProbeForTest(agreementError())).toBe('agreement');
+    expect(classifyProbeForTest(roleError())).toBe('forbidden');
+  });
+
+  it('stops probing when the account is blocked — five more 403s teach nothing', async () => {
+    let calls = 0;
+    const http = {
+      get: async () => {
+        calls++;
+        throw agreementError();
+      },
+    } as any;
+
+    const report = await probeCapabilities(http, 'agreement' as ProbeState, 'app-1');
+    expect(calls, 'probed a family after the account was already known to be blocked').toBe(0);
+    expect(report.summary).toMatch(/unsigned or expired agreement/i);
+    expect(report.summary).toMatch(/Account Holder/);
+    expect(report.reports).toBe('agreement');
+  });
+});


### PR DESCRIPTION
Reopened from #87, which GitHub closed when its base branch (`claude/heimdall-capability-probe`) was deleted on merging #86. Same commit, rebased onto main, one file of it now sitting on the merged probe rather than under it.

Apple answers **"your key is scoped too narrowly"** and **"nobody signed the current agreement"** with the same 403, and the two lead opposite ways:

| | Fixed by |
|:--|:--|
| Scoped key | a role change, or a new key |
| Unsigned agreement | the **Account Holder** accepting terms at developer.apple.com — no key ever issued will work until then |

The generic 403 hint pointed at roles and Finance/Admin, so the second case sends the reader rotating credentials that were never the problem.

### Why it is worth the fifteen lines

Not a rare state. Apple ships a new Program License Agreement roughly twice a year and blocks the API once the grace period ends — [the current one takes effect 1 October 2026](https://developer.apple.com/news/) — so every account meets it, and meets it as a morning when everything abruptly returns 403 with no warning in the response.

There is also nothing else to go on: `/v1/agreements` was removed and Apple exposes no endpoint reporting agreement state, so `FORBIDDEN.REQUIRED_AGREEMENTS_*` on the error body is the only signal that exists.

### What changed

- `AscApiError.requiresAgreement` — true only for a 403 carrying that code
- The HTTP layer picks the agreement hint over the roles hint for those errors. It names the Account Holder, the developer website, that a new key will not help, and that "Agreements, Tax, and Banking" in App Store Connect is a *different* agreement — the usual wrong turn
- `asc__status`'s capability probe (from #86) gains an `agreement` state and stops early on it, exactly as it already does for an unauthenticated key: five more calls to collect five identical 403s teach nothing

### Tests

8 new. The ones that matter are the negatives — an ordinary 403 must not claim it, and a 401 carrying the code must not either, since that is the key failing rather than the account.

Full suite after the rebase: 44 files, 647 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)