### PR TITLE
docs: least privilege, and how to read the new capability probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ There is nothing to memorise — ask *"is there a tool for in-app events?"* and 
 
 Changing a price, handing out Admin or deleting something asks for confirmation before it runs, showing what would change, so a misread instruction cannot execute unchecked. This is the default for the four risk levels that are hard to undo — revenue, destructive, infrastructure, access — and everything else runs on your client's own tool approval. `--confirm` asks before every write instead; `--no-confirm` asks before none; `--read-only` drops mutating tools entirely. See [Security](.github/SECURITY.md).
 
+#### Least privilege, and a way to check it
+
+Apple never returns a key's role from any endpoint, so **App Manager** — not Admin — is the right default for day-to-day release work; Admin only earns its place for user management and for the one-time first request of a new analytics report type, which has no path in the App Store Connect UI at all. Contracts, tax and banking sit behind the Account Holder alone, reachable by no API key regardless of role. Call `asc__status` with `check_capabilities: true` to see what a key actually has rather than guessing from a 403 mid-task. Full breakdown in the [Guide](docs/GUIDE.md#least-privilege-in-practice).
+
 #### Local by design, not by default
 
 MCP guidance recommends remote HTTP servers: one URL, no install, updates you control. Heimdall runs locally over stdio instead, and that is a deliberate trade. Running locally, the key never leaves your machine: Heimdall reads it from the Keychain, signs a short-lived token, and talks to Apple directly. Nothing sits in between.
@@ -186,6 +190,10 @@ Hiçbir şeyi ezberlemeniz gerekmez — *"uygulama içi etkinlikler için bir ar
 #### Riskli yazmalar önce sorar
 
 Fiyat değiştirme, Admin yetkisi verme ya da bir şeyi silme çalışmadan önce onay ister ve neyin değişeceğini gösterir; böylece yanlış anlaşılmış bir talimat kontrolsüz çalışamaz. Bu, geri alması zor dört risk seviyesinde varsayılandır — revenue, destructive, infrastructure, access — geri kalan her şey client'ınızın kendi araç onayıyla çalışır. `--confirm` her yazmadan önce sorar, `--no-confirm` hiç sormaz, `--read-only` mutasyon araçlarını tamamen kaldırır. Bkz. [Güvenlik](.github/SECURITY.md).
+
+#### En az yetki, ve onu kontrol etmenin yolu
+
+Apple hiçbir endpoint'ten anahtarın rolünü döndürmüyor, bu yüzden günlük release işi için doğru varsayılan Admin değil **App Manager** — Admin yalnızca kullanıcı yönetimi ve yeni bir analytics rapor tipinin bir kereye mahsus ilk isteği için gerekli, ki bunun App Store Connect arayüzünde hiçbir yolu yok. Sözleşme, vergi ve banka bilgileri yalnızca Account Holder'a açık, role bakılmaksızın hiçbir API anahtarı oraya ulaşamıyor. Bir anahtarın gerçekte neye sahip olduğunu görmek için `asc__status`'u `check_capabilities: true` ile çağırın — görev ortasında gelen bir 403'ten tahmin etmek yerine. Tam döküm [Rehber](docs/GUIDE.md#pratikte-en-az-yetki)'de.
 
 #### Yerelde çalışması tercih, eksiklik değil
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -31,6 +31,31 @@ The role you give the key decides which permissions an agent gets — and what i
 
 Most day-to-day release work needs only **App Manager**; add **Developer** for CI build uploads, or **Finance**/**Sales** only if you actually run `analytics` tools. For how to cap the risk regardless of role, see [SECURITY.md](../.github/SECURITY.md) — `--read-only` mode removes all mutation risk.
 
+### Least privilege in practice
+
+The table above is what you *choose* when a key is created. No endpoint reads it back afterward — a team key's role is fixed at creation with no API to confirm it, and an individual key silently inherits whatever roles and app restrictions its creator has. So the honest way to know what a key can actually do is to ask it, not to remember what you picked.
+
+**App Manager covers almost everything.** Versions, builds, TestFlight, pricing, subscriptions, metadata — all of it. Two things sit outside it on purpose:
+
+- **User management is Admin-only.** Adding a team member, changing a role, revoking access — all of it needs Admin, because it is the one capability that can affect people other than you.
+- **First requesting a given analytics report type is Admin-only, once.** After that first request the report exists and Sales, Finance or a key with "Access to Reports" can read it — but *starting* a report type Apple has not seen this account request before needs Admin, and there is no path to that first request in the App Store Connect web UI at all. It has to come from the API, with an Admin key.
+
+**Nothing reaches the Account Holder's area, at any role.** Contracts, tax forms and banking live on their own page — "Agreements, Tax, and Banking" — and no API key opens it, Admin included. That page is legally tied to one person on the account, and only that person, signed in on the developer website, can touch it. If a task needs that page, it needs the Account Holder at a keyboard, not a wider key.
+
+An unsigned or expired agreement is the same story wearing a different status code: Apple answers with a 403, exactly like a role that is too narrow, but no role fixes it — the account itself is blocked until the Account Holder signs in and accepts the current Program License Agreement.
+
+**Reading what a key actually has:** call `asc__status` with `check_capabilities: true`. It probes five families with one cheap request each — `reports` (Analytics Reports API), `metadata` (app info), `reviews` (customer reviews), `userManagement`, `provisioning` (certificates and profiles) — and reports each as:
+
+| State | Meaning |
+|:--|:--|
+| `ok` | The probe succeeded. This family is open. |
+| `forbidden` | Apple refused this specific request. The key authenticates; this family is not in its role. |
+| `unauthorized` | The key itself is not authenticating — every family will read this way, and the fix is the key, not a role. |
+| `agreement` | The account has an unsigned or expired agreement — the same 403 a narrow role would give, for an unrelated reason. Only the Account Holder can clear it, at [developer.apple.com/account](https://developer.apple.com/account); no key, however wide, fixes this. |
+| `unknown` | Inconclusive: a network failure, a 5xx, or (for `reports`/`metadata`/`reviews`) no app on the account to probe against. Never treat this as a denial — it is not one. |
+
+`unauthorized` and `agreement` on the baseline both short-circuit the rest of the probe: five more requests that would all fail for the same reason answer nothing new, so they are not sent. A `forbidden` on `reports` alone, with everything else `ok`, is exactly the first-request-needs-Admin case above — read literally, not as evidence the whole key is broken.
+
 ### Install
 
 ```bash
@@ -435,6 +460,31 @@ Anahtara verdiğiniz rol, bir agent'ın hangi yetkileri aldığını — ve bir 
 
 > [!NOTE]
 > Günlük release işlerinin çoğu yalnızca **App Manager** ister; CI build yüklemeleri için **Developer** ekleyin, sadece gerçekten `analytics` araçlarını kullanacaksanız **Finance**/**Sales** ekleyin. Role bakılmaksızın riski nasıl sınırlayacağınız için [SECURITY.md](../.github/SECURITY.md)'ye bakın — `--read-only` modu tüm mutasyon riskini kaldırır.
+
+### Pratikte en az yetki
+
+Yukarıdaki tablo, anahtar oluşturulurken *seçtiğiniz* şey. Hiçbir endpoint bunu sonradan geri okumuyor — bir takım anahtarının rolü oluşturulurken sabitleniyor ve bunu doğrulayacak bir API yok; bireysel bir anahtar ise oluşturan kişinin rollerini ve uygulama kısıtlarını sessizce miras alıyor. Yani bir anahtarın gerçekte ne yapabildiğini bilmenin dürüst yolu, ne seçtiğinizi hatırlamak değil, ona sormak.
+
+**App Manager neredeyse her şeyi açar.** Sürümler, build'ler, TestFlight, fiyatlandırma, abonelikler, metadata — hepsi. Bilerek dışarıda bırakılan iki şey var:
+
+- **Kullanıcı yönetimi yalnızca Admin'e açık.** Takım üyesi eklemek, rol değiştirmek, erişimi iptal etmek — hepsi Admin ister, çünkü sizin dışınızdaki insanları etkileyebilecek tek yetenek bu.
+- **Bir analytics rapor tipini ilk kez istemek, bir kez, yalnızca Admin'e açık.** İlk istekten sonra rapor var olur ve Sales, Finance ya da "Access to Reports" yetkili bir anahtar onu okuyabilir — ama Apple'ın bu hesaptan daha önce hiç istenmemiş bir rapor tipini *başlatmak*, Admin ister ve bu ilk isteğe App Store Connect web arayüzünde hiçbir yol yok. Yalnızca API'den, bir Admin anahtarıyla yapılabilir.
+
+**Account Holder alanına, hiçbir rolle ulaşılmıyor.** Sözleşmeler, vergi formları ve banka bilgileri kendi sayfasında yaşıyor — "Agreements, Tax, and Banking" — ve hiçbir API anahtarı, Admin dahil, oraya açılmıyor. O sayfa hesaptaki tek bir kişiye yasal olarak bağlı ve yalnızca o kişi, developer web sitesinde oturum açmış hâlde, ona dokunabilir. Bir görev o sayfayı gerektiriyorsa, ihtiyacı olan daha geniş bir anahtar değil, klavye başında Account Holder'ın kendisi.
+
+İmzasız ya da süresi dolmuş bir sözleşme, farklı bir durum koduyla aynı hikâye: Apple 403 döner, tıpkı dar bir rol gibi, ama hiçbir rol bunu düzeltmez — hesabın kendisi, Account Holder oturum açıp güncel Program Lisans Sözleşmesi'ni kabul edene kadar bloklu.
+
+**Bir anahtarın gerçekte neye sahip olduğunu okumak:** `asc__status`'u `check_capabilities: true` ile çağırın. Beşi de ucuz birer istekle beş aileyi yoklar — `reports` (Analytics Reports API), `metadata` (uygulama bilgisi), `reviews` (müşteri yorumları), `userManagement`, `provisioning` (sertifikalar ve profiller) — ve her birini şöyle raporlar:
+
+| Durum | Anlamı |
+|:--|:--|
+| `ok` | Prob başarılı oldu. Bu aile açık. |
+| `forbidden` | Apple bu belirli isteği reddetti. Anahtar kimlik doğruluyor; bu aile onun rolünde değil. |
+| `unauthorized` | Anahtarın kendisi kimlik doğrulamıyor — her aile böyle okunacak, çözüm bir rol değil anahtarın kendisi. |
+| `agreement` | Hesabın imzasız ya da süresi dolmuş bir sözleşmesi var — dar bir rolün vereceğiyle aynı 403, alakasız bir sebepten. Yalnızca Account Holder çözebilir, [developer.apple.com/account](https://developer.apple.com/account)'ta; hiçbir anahtar, ne kadar geniş olursa olsun, bunu düzeltmez. |
+| `unknown` | Belirsiz: ağ hatası, 5xx, ya da (`reports`/`metadata`/`reviews` için) hesapta yoklanacak uygulama yok. Bunu asla bir ret olarak okumayın — değil. |
+
+Baseline'daki `unauthorized` ve `agreement`, ikisi de probun geri kalanını kısa devre yaptırır: aynı sebeple aynı şekilde başarısız olacak beş istek daha atmak hiçbir şey öğretmez, o yüzden atılmazlar. Geri kalanı `ok` iken tek başına `reports`'ta bir `forbidden`, yukarıdaki "ilk istek Admin ister" durumunun ta kendisi — anahtarın tamamen bozuk olduğuna kanıt olarak değil, olduğu gibi okunmalı.
 
 ### Kurun
 

--- a/skills/heimdall/SKILL.md
+++ b/skills/heimdall/SKILL.md
@@ -38,6 +38,38 @@ different operation — never the shell. If the credentials genuinely are not
 configured, `asc__status` says so, and the fix is `setup` (below), which only
 the user can run.
 
+## Least privilege
+
+No endpoint returns a key's role, so a 403 partway through a task is often the
+first anyone learns the key is narrower than assumed. Before telling the user
+their key is broken or asking them to mint an Admin one, call `asc__status`
+with `check_capabilities: true` — one cheap probe per role family
+(`reports`, `metadata`, `reviews`, `userManagement`, `provisioning`), each
+`ok` / `forbidden` / `unauthorized` / `agreement` / `unknown`. `unknown` means
+the probe was inconclusive (network, a 5xx, no app to test against) —
+`agreement` means the account has an unsigned or expired agreement, the same
+403 a narrow role gives for an unrelated reason. Never read either as a
+denial that a wider key would fix — `agreement` in particular is not a role
+problem at all, and no key clears it.
+
+Four facts worth knowing before reaching for a wider key:
+
+- **App Manager covers almost everything** — versions, builds, TestFlight,
+  pricing, metadata. Most 403s are not a reason to go to Admin.
+- **Admin is only load-bearing for two things**: user management, and the
+  first-ever request of an analytics report type an account has never asked
+  for before — that one request has no path in the App Store Connect UI at
+  all, API-only. A `forbidden` on `reports` alone, everything else `ok`, is
+  usually exactly this, not a broken key.
+- **An `agreement` result means the account is blocked, not the key.** Say so
+  and stop — only the Account Holder, signed in at
+  [developer.apple.com/account](https://developer.apple.com/account), can
+  clear it. Suggesting a new key here wastes a rotation on a problem it
+  cannot touch.
+- **Contracts, tax and banking are Account Holder-only, at every role.** No
+  key reaches that page, Admin included. If a task needs it, say so and stop
+  — the fix is a person signing in, not a wider key.
+
 ## Installing it
 
 Two steps, and they are not both yours. **You register. The user hands over the


### PR DESCRIPTION
## What changes, and why

The role table in `docs/GUIDE.md` already answered "which role do I pick when creating a key". It never answered "what does a key actually need day to day" or "how do I check what one has" — and #86 (plus #88's `agreement` state) just shipped the tool that answers the second question. This adds both, in the three places someone would look: `docs/GUIDE.md` for the full breakdown, `README.md` for a one-paragraph pointer, `skills/heimdall/SKILL.md` for what the agent itself should do on a 403.

Three facts anchor all three:

- **App Manager covers almost everything.** Most 403s are not a reason to reach for Admin.
- **Admin only earns its place for two things**: user management, and the one-time first request of an analytics report type an account has never asked for before — which has no path in the App Store Connect UI at all, API-only.
- **Contracts, tax and banking are Account Holder-only, at every role.** No key reaches that page, Admin included.

## Related issue

H2 of 2 — follow-up to #86. Rebased onto main after #88 merged, since #88 added a fifth `ProbeState` (`agreement`) this branch was cut before; the states table and the short-circuit note cover all five now, not the four that existed when H2 started.

## Placement note

`skills/heimdall/SKILL.md`'s addition sits directly **under** the credential-boundary section #85 rewrote — added after it, nothing in that section touched. It was correct as written; this is a different concern (what a role permits, not whether the key is reachable at all).

## Checklist

- [x] `npm test` and `npm run typecheck` pass
- [x] Generator touched? No — `src/generated/` is untouched
- [x] Descriptions or tool surface touched? No — docs only, so AX ceilings are unaffected
- [x] Docs updated if behaviour changed — this is the docs update; the behaviour itself shipped in #86 and #88
- [x] No credentials, private keys, or real App Store Connect identifiers in the diff

## Tool count / AX impact

No change. Confirmed via `npm run ax:report` and `tests/ax-audit.test.ts` / `tests/profile-invariants.test.ts` / `tests/description-quality.test.ts` / `tests/search-intents.test.ts`, all passing unchanged.

## How this was verified

`npm run build && npm test` — 647 passed, 9 skipped, 44 files, matching current main (post-#88). `npm run typecheck` clean. `tests/skill.test.ts` and `tests/examples.test.ts` pass, which are the ones that read `SKILL.md` and cross-check tool names cited in the docs.

---
_Generated by Claude Code_